### PR TITLE
fix: replace use of `schema:title` by `schema:name`

### DIFF
--- a/src/main/java/ch/psi/ord/core/RoCrateExporter.java
+++ b/src/main/java/ch/psi/ord/core/RoCrateExporter.java
@@ -93,7 +93,7 @@ public class RoCrateExporter {
     publicationBuilder
         .addProperty(
             SchemaDO.datePublished.getLocalName(), Long.toString(publication.getPublicationYear()))
-        .addProperty(SchemaDO.title.getLocalName(), publication.getTitle())
+        .addProperty(SchemaDO.name.getLocalName(), publication.getTitle())
         .addProperty(SchemaDO._abstract.getLocalName(), publication.getAbstract())
         .addProperty(SchemaDO.additionalType.getLocalName(), publication.getResourceType())
         .addProperty(SchemaDO.sdDatePublished.getLocalName(), publication.getRegisteredTime())

--- a/src/main/java/ch/psi/ord/core/StaticEntities.java
+++ b/src/main/java/ch/psi/ord/core/StaticEntities.java
@@ -44,7 +44,6 @@ public class StaticEntities {
             SchemaDO.publisher,
             SchemaDO.datePublished,
             SchemaDO.about,
-            SchemaDO.title,
             SchemaDO.additionalType,
             SchemaDO.sdDatePublished,
             SchemaDO.creativeWorkStatus,

--- a/src/main/java/ch/psi/ord/model/Publication.java
+++ b/src/main/java/ch/psi/ord/model/Publication.java
@@ -19,7 +19,7 @@ public class Publication {
   @RdfProperty(uri = SchemaDO.NS + "creator", minCardinality = 1)
   private List<Person> creator = new ArrayList<>();
 
-  @RdfProperty(uri = SchemaDO.NS + "title", minCardinality = 1)
+  @RdfProperty(uri = SchemaDO.NS + "name", minCardinality = 1)
   private String title;
 
   @RdfProperty(uri = SchemaDO.NS + "publisher", minCardinality = 1)

--- a/src/test/resources/one-publication.json
+++ b/src/test/resources/one-publication.json
@@ -7,7 +7,6 @@
         "about": "https://schema.org/about",
         "description": "https://schema.org/description",
         "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
-        "title": "https://schema.org/title",
         "dateCreated": "https://schema.org/dateCreated",
         "rangeIncludes": "https://schema.org/rangeIncludes",
         "creativeWorkStatus": "https://schema.org/creativeWorkStatus",
@@ -132,7 +131,7 @@
                 "@id": "https://creativecommons.org/licenses/by-sa/4.0/"
             },
             "datePublished": "2023",
-            "title": "A test pub made of 3 ds",
+            "name": "A test pub made of 3 ds",
             "abstract": "3 ds",
             "additionalType": "raw",
             "sdDatePublished": "2023-01-26T13:02:38.341Z",


### PR DESCRIPTION
[schema:title](https://schema.org/title) is only applicable to the [schema:JobPosting](https://schema.org/JobPosting) type.

The appropriate property for a CreativeWork is name