### PR TITLE
fix: integer value serialized as double in export

### DIFF
--- a/src/main/java/ch/psi/ord/core/RoCrateExporter.java
+++ b/src/main/java/ch/psi/ord/core/RoCrateExporter.java
@@ -125,8 +125,8 @@ public class RoCrateExporter {
               publicationBuilder.addProperty(formatScicatId("relatedPublications"), p);
             });
     publicationBuilder
-        .addProperty(formatScicatId("numberOfFiles"), publication.getNumberOfFiles())
-        .addProperty(formatScicatId("sizeOfArchive"), publication.getSizeOfArchive())
+        .addProperty(formatScicatId("numberOfFiles"), (int) publication.getNumberOfFiles())
+        .addProperty(formatScicatId("sizeOfArchive"), (int) publication.getSizeOfArchive())
         .addProperty(formatScicatId("scicatUser"), publication.getScicatUser());
 
     DataEntity publicationEntity = publicationBuilder.build();


### PR DESCRIPTION
Cast from `long` to `int` when writing the crate.
Otherwise the overload resolution uses  `double` rather than `int`.
