### PR TITLE
chore: change dependency updates as chore

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,7 +9,7 @@ updates:
    schedule:
      interval: daily
    commit-message:
-     prefix: fix
+     prefix: chore
      prefix-development: chore
      include: scope
  - package-ecosystem: "docker"


### PR DESCRIPTION
this prevents creating a release each time a dependency is updated