### PR TITLE
fix: query param name for `/api/v3/PublishedData/count`

### DIFF
--- a/src/main/java/ch/psi/scicat/client/ScicatClient.java
+++ b/src/main/java/ch/psi/scicat/client/ScicatClient.java
@@ -103,9 +103,9 @@ public class ScicatClient {
   }
 
   public RestResponse<CountResponse> countPublishedData(
-      @QueryParam("filter") String filter, @HeaderParam("Authorization") String accessToken) {
+      @QueryParam("where") String where, @HeaderParam("Authorization") String accessToken) {
     RestResponse<CountResponse> clientResponse =
-        scicatService.countPublishedData(filter, accessToken);
+        scicatService.countPublishedData(where, accessToken);
     return RestResponse.fromResponse(clientResponse);
   }
 

--- a/src/main/java/ch/psi/scicat/client/ScicatService.java
+++ b/src/main/java/ch/psi/scicat/client/ScicatService.java
@@ -57,7 +57,7 @@ public interface ScicatService {
   @GET
   @Path("/api/v3/publisheddata/count")
   RestResponse<CountResponse> countPublishedData(
-      @QueryParam("filter") String filter, @HeaderParam("Authorization") String accessToken);
+      @QueryParam("where") String where, @HeaderParam("Authorization") String accessToken);
 
   @POST
   @Path("/api/v3/publisheddata")


### PR DESCRIPTION
was previously using `filter` rather than `where`, the backend would ignore the query param and return the total count of PublishedData, making every import result in a 409 Conflict