### PR TITLE
fix(zenodo): force `distribution` as an array

### DIFF
--- a/src/main/java/ch/psi/ord/api/ZenodoController.java
+++ b/src/main/java/ch/psi/ord/api/ZenodoController.java
@@ -18,7 +18,7 @@ public class ZenodoController {
   @Produces(ExtraMediaType.APPLICATION_JSONLD)
   public Response exportDoi(@PathParam("doi") String doi) throws Exception {
     try {
-      return Response.ok(exporter.exportDoi(doi)).build();
+      return Response.ok(exporter.exportDoi(doi).toString()).build();
     } catch (WebApplicationException e) {
       Response res = e.getResponse();
       return Response.status(res.getStatus())

--- a/src/main/java/ch/psi/ord/core/ZenodoExporter.java
+++ b/src/main/java/ch/psi/ord/core/ZenodoExporter.java
@@ -17,6 +17,7 @@ import com.apicatalog.jsonld.document.Document;
 import com.apicatalog.jsonld.document.JsonDocument;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.json.JsonObject;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.ArrayList;
@@ -49,7 +50,10 @@ public class ZenodoExporter {
               new StringReader(
                   """
                       {
-                        "@context": {"@vocab": "https://schema.org/"},
+                        "@context": {
+                          "@vocab": "https://schema.org/",
+                          "distribution": { "@container": "@set" }
+                        },
                         "@type": "Dataset",
                         "@embed": "@always"
                       }
@@ -59,12 +63,16 @@ public class ZenodoExporter {
     }
   }
 
-  public String exportDoi(String doi) throws RdfSerializationException, JsonLdError {
+  public JsonObject exportDoi(String doi) throws RdfSerializationException, JsonLdError {
     PublishedDataUrls brokerResponse = s3BrokerService.getPublishedDataUrls(doi);
     List<DataDownload> distribution = new ArrayList<>();
     for (DatasetUrls datasetUrls : brokerResponse.getUrls().values()) {
       if (datasetUrls.s3Uri != null) {
-        distribution.add(new DataDownload().setName("S3 URI").setContentUrl(datasetUrls.s3Uri));
+        distribution.add(
+            new DataDownload()
+                .setName("S3 URI")
+                .setContentUrl(datasetUrls.s3Uri)
+                .setExpirationDate(datasetUrls.getExpires()));
       }
 
       for (S3Url s3Url : datasetUrls.getUrls()) {
@@ -90,6 +98,6 @@ public class ZenodoExporter {
         .output(sw);
     Document doc = JsonDocument.of(new StringReader(sw.toString()));
 
-    return JsonLd.frame(doc, zenodoFrame).get().toString();
+    return JsonLd.frame(doc, zenodoFrame).get();
   }
 }

--- a/src/test/java/ch/psi/ord/api/ZenodoControllerTest.java
+++ b/src/test/java/ch/psi/ord/api/ZenodoControllerTest.java
@@ -119,10 +119,10 @@ public class ZenodoControllerTest extends EndpointTest {
             containsInAnyOrder(TestData.hzdrPub1.getCreator().toArray()))
         .body(
             SchemaDO.distribution.getLocalName() + ".@type",
-            equalTo(SchemaDO.DataDownload.getLocalName()))
+            everyItem(equalTo(SchemaDO.DataDownload.getLocalName())))
         .body(
             SchemaDO.distribution.getLocalName() + "." + SchemaDO.expires.getLocalName(),
-            isDateExpired());
+            everyItem(isDateExpired()));
   }
 
   @Test

--- a/src/test/java/ch/psi/ord/core/ZenodoExporterTest.java
+++ b/src/test/java/ch/psi/ord/core/ZenodoExporterTest.java
@@ -1,0 +1,55 @@
+package ch.psi.ord.core;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.when;
+
+import ch.psi.s3_broker.client.S3BrokerService;
+import ch.psi.s3_broker.model.DatasetUrls;
+import ch.psi.s3_broker.model.PublishedDataUrls;
+import ch.psi.s3_broker.model.S3Url;
+import ch.psi.scicat.TestData;
+import ch.psi.scicat.client.ScicatClient;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.jboss.resteasy.reactive.RestResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+public class ZenodoExporterTest {
+  @Inject ZenodoExporter zenodoExporter;
+  @InjectMock protected ScicatClient scicatClient;
+  @InjectMock @RestClient protected S3BrokerService s3BrokerService;
+
+  @Test
+  @DisplayName("distribution should be serialized as an array when single-valued")
+  public void test00() {
+    Instant expirationDate = Instant.parse("2036-02-28T09:55:19Z");
+    when(scicatClient.getPublishedDataById(TestData.psiPub1.getDoi()))
+        .thenReturn(RestResponse.ok(TestData.psiPub1));
+    when(s3BrokerService.getPublishedDataUrls(TestData.psiPub1.getDoi()))
+        .thenReturn(
+            new PublishedDataUrls()
+                .setExpires(expirationDate)
+                .setUrls(
+                    Map.of(
+                        "PID.SAMPLE.PREFIX/psi_ds3",
+                        new DatasetUrls()
+                            .setExpires(Instant.parse("2036-02-28T09:55:19Z"))
+                            .setUrls(
+                                List.of(
+                                    new S3Url()
+                                        .setUrl(
+                                            "https://example.com/tenant:bucket/PID.SAMPLE.PREFIX/psi_ds3/461f1e85-08fe-4972-85e9-1a5d8b0431ee_0_2025-10-03-11-12-56.tar")
+                                        .setExpires(Instant.parse("2036-02-28T09:55:19Z")))))));
+
+    assertDoesNotThrow(
+        () ->
+            zenodoExporter.exportDoi(TestData.psiPub1.getDoi()).get("distribution").asJsonArray());
+  }
+}


### PR DESCRIPTION
Also adds `expires` property for S3 prefix URI entries