### PR TITLE
ci: allow creation of pre-releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - 'rc/**'
 
 env:
   devImage: ghcr.io/${{ github.repository }}-devcontainer

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,6 +1,10 @@
 {
   "branches": [
-    "main"
+    "main",
+    {
+      "name": "rc/*",
+      "prerelease": "${name.replace(/^.*rc\\//, \"rc-\")}"
+    }
   ],
   "plugins": [
     "@semantic-release/commit-analyzer",


### PR DESCRIPTION
Branches named with the prefix `rc/` will be released as pre-releases
branch `rc/openbis-import` -> `v1.0.0-rc-openbis-import.1`