### PR TITLE
feat(validate): accept individual files in Publications

### DIFF
--- a/src/main/java/ch/psi/ord/core/RoCrate.java
+++ b/src/main/java/ch/psi/ord/core/RoCrate.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.zip.ZipException;
 import lombok.Getter;
+import lombok.experimental.Accessors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
@@ -37,6 +38,10 @@ public class RoCrate implements AutoCloseable {
   @Getter private Path base = DEFAULT_BASE;
   @Getter private Model model;
 
+  @Getter
+  @Accessors(fluent = true)
+  private boolean hasAttachedData = false;
+
   private RoCrate() {}
 
   public static RoCrate fromMetadata(InputStream metadataDescriptor)
@@ -52,6 +57,7 @@ public class RoCrate implements AutoCloseable {
     RoCrate crate = new RoCrate();
     crate.extract(zip);
     crate.readMetadataDescriptor();
+    crate.hasAttachedData = true;
     return crate;
   }
 

--- a/src/main/java/ch/psi/ord/core/RoCrateImporter.java
+++ b/src/main/java/ch/psi/ord/core/RoCrateImporter.java
@@ -23,10 +23,11 @@ import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response.Status;
-import java.net.URI;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -171,6 +172,11 @@ public class RoCrateImporter {
   }
 
   public List<MissingDataError> validateArchiveContent() {
+    // NOTE: when only the metadata descriptor is uploaded we can't validate the archive content
+    if (!crate.hasAttachedData()) {
+      return Collections.emptyList();
+    }
+
     Set<Resource> referencedDatafiles =
         listResourcesOfType(
             inferredModel,
@@ -183,17 +189,16 @@ public class RoCrateImporter {
             SchemaDO.MediaObject,
             r -> r.getURI() != null && r.getURI().startsWith("file:///")));
 
-    Set<URI> extractedFiles =
-        this.crate.listFiles().stream().map(Path::toUri).collect(Collectors.toSet());
+    Set<Path> pathsToCheck =
+        referencedDatafiles.stream()
+            .map(r -> Paths.get(r.getURI().replace("file://", "/")).toAbsolutePath())
+            .collect(Collectors.toSet());
+
     List<MissingDataError> errors = new ArrayList<>();
-    referencedDatafiles.forEach(
-        r -> {
-          if (!extractedFiles.contains(URI.create(r.getURI()))) {
-            log.info("URI: {}", r.getURI());
-            log.info("Base: {}", this.crate.getBase());
-            errors.add(
-                new MissingDataError(
-                    r.getURI().replace("file://" + this.crate.getBase().toString(), "")));
+    pathsToCheck.forEach(
+        dataEntityPath -> {
+          if (!dataEntityPath.toFile().exists()) {
+            errors.add(new MissingDataError(crate.getBase().relativize(dataEntityPath).toString()));
           }
         });
 

--- a/src/main/java/ch/psi/ord/model/ExportFormat.java
+++ b/src/main/java/ch/psi/ord/model/ExportFormat.java
@@ -16,6 +16,11 @@ public enum ExportFormat {
     this.value = value;
   }
 
+  @Override
+  public String toString() {
+    return this.value;
+  }
+
   public static ExportFormat fromString(String value) {
     for (ExportFormat format : ExportFormat.values()) {
       if (format.value.equalsIgnoreCase(value)) {

--- a/src/main/java/ch/psi/ord/model/MissingDataError.java
+++ b/src/main/java/ch/psi/ord/model/MissingDataError.java
@@ -14,7 +14,6 @@ public class MissingDataError implements ValidationError {
   @Override
   public String getMessage() {
     return String.format(
-        "The path '%s' is referenced in the metadata descriptor but absent from the archive ",
-        path);
+        "The path '%s' is referenced in the metadata descriptor but absent from the archive", path);
   }
 }

--- a/src/main/java/ch/psi/ord/model/Publication.java
+++ b/src/main/java/ch/psi/ord/model/Publication.java
@@ -1,12 +1,28 @@
 package ch.psi.ord.model;
 
+import static ch.psi.rdf.RdfUtils.isOfType;
+import static ch.psi.rdf.RdfUtils.listProperties;
+
+import ch.psi.ord.model.Publication.Parts.PartsDeserializer;
 import ch.psi.rdf.annotations.RdfClass;
+import ch.psi.rdf.annotations.RdfDeserialize;
 import ch.psi.rdf.annotations.RdfProperty;
+import ch.psi.rdf.deser.RdfDeserializationContext;
+import ch.psi.rdf.deser.RdfDeserializationException;
+import ch.psi.rdf.deser.RdfDeserializer;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.vocabulary.SchemaDO;
 
 @Getter
@@ -41,6 +57,61 @@ public class Publication {
   @RdfProperty(uri = SchemaDO.NS + "description", minCardinality = 1)
   private String description;
 
-  @RdfProperty(uri = SchemaDO.NS + "hasPart")
-  private List<Dataset> hasPart = new ArrayList<>();
+  @RdfProperty(uri = SchemaDO.NS + "hasPart", minCardinality = 1)
+  private Parts hasPart;
+
+  @Data
+  @RdfDeserialize(using = PartsDeserializer.class)
+  public static class Parts {
+    private List<Dataset> datasets = new ArrayList<>();
+    private Map<String, String> files = new HashMap<>();
+
+    @Slf4j
+    public static class PartsDeserializer implements RdfDeserializer<Parts> {
+      @Override
+      public Parts deserialize(RDFNode node, RdfDeserializationContext context)
+          throws RdfDeserializationException {
+        Parts result = new Parts();
+        Resource subject =
+            context
+                .getCurrentSubject()
+                .orElseThrow(() -> new RdfDeserializationException("current subject is not set"));
+
+        collectDataEntries(subject, result, context);
+
+        if (result.datasets.isEmpty() && result.files.isEmpty()) {
+          context.addError(
+              new PropertyError(
+                  subject.toString(),
+                  SchemaDO.hasPart.getURI(),
+                  String.format(
+                      "sub-tree should contain at least one '%s' or '%s'",
+                      SchemaDO.Dataset, SchemaDO.MediaObject)));
+        }
+
+        return result;
+      }
+
+      private void collectDataEntries(
+          Resource subject, Parts result, RdfDeserializationContext context)
+          throws RdfDeserializationException {
+        Set<Resource> parts =
+            listProperties(subject, SchemaDO.hasPart).stream()
+                .filter(node -> node.isResource())
+                .map(node -> node.asResource())
+                .collect(Collectors.toSet());
+
+        for (Resource r : parts) {
+          if (isOfType(r, SchemaDO.Dataset)) {
+            Dataset d = context.getDeserializer(Dataset.class).deserialize(r, context);
+            result.datasets.add(d);
+          } else if (isOfType(r, SchemaDO.MediaObject)) {
+            result.files.putIfAbsent(r.toString(), r.getURI().replace("file://", ""));
+          } else {
+            collectDataEntries(r, result, context);
+          }
+        }
+      }
+    }
+  }
 }

--- a/src/main/java/ch/psi/ord/model/Publication.java
+++ b/src/main/java/ch/psi/ord/model/Publication.java
@@ -97,7 +97,7 @@ public class Publication {
           throws RdfDeserializationException {
         Set<Resource> parts =
             listProperties(subject, SchemaDO.hasPart).stream()
-                .filter(node -> node.isResource())
+                .filter(node -> node.isURIResource())
                 .map(node -> node.asResource())
                 .collect(Collectors.toSet());
 

--- a/src/main/java/ch/psi/rdf/RdfUtils.java
+++ b/src/main/java/ch/psi/rdf/RdfUtils.java
@@ -97,10 +97,11 @@ public class RdfUtils {
   }
 
   public static Set<RDFNode> listProperties(Resource subject, Property p) {
-    Set<RDFNode> res = subject.getModel().listObjectsOfProperty(subject, p).toSet();
-    res.addAll(subject.getModel().listObjectsOfProperty(subject, switchScheme(p)).toSet());
-
-    return res;
+    return subject
+        .getModel()
+        .listObjectsOfProperty(subject, p)
+        .andThen(subject.getModel().listObjectsOfProperty(subject, switchScheme(p)))
+        .toSet();
   }
 
   public static Set<Resource> listResourcesOfType(Model model, Resource type) {

--- a/src/main/java/ch/psi/rdf/deser/ObjectDeserializer.java
+++ b/src/main/java/ch/psi/rdf/deser/ObjectDeserializer.java
@@ -67,6 +67,7 @@ public class ObjectDeserializer<T> implements RdfDeserializer<T> {
           String.format("Failed to create an instance of %s", clazz.getName()), e);
     }
     Resource subject = node.asResource();
+    context.setCurrentSubject(subject);
     setUriFields(subject, obj);
     checkType(subject, rdfClassAnnotation.typesUri()).ifPresent(e -> context.addError(e));
 
@@ -109,6 +110,7 @@ public class ObjectDeserializer<T> implements RdfDeserializer<T> {
         setField(field, obj, value);
       }
     }
+    context.resetCurrentSubject();
 
     return obj;
   }

--- a/src/main/java/ch/psi/rdf/deser/ObjectDeserializer.java
+++ b/src/main/java/ch/psi/rdf/deser/ObjectDeserializer.java
@@ -67,50 +67,54 @@ public class ObjectDeserializer<T> implements RdfDeserializer<T> {
           String.format("Failed to create an instance of %s", clazz.getName()), e);
     }
     Resource subject = node.asResource();
-    context.setCurrentSubject(subject);
-    setUriFields(subject, obj);
-    checkType(subject, rdfClassAnnotation.typesUri()).ifPresent(e -> context.addError(e));
+    context.pushCurrentSubject(subject);
+    try {
+      setUriFields(subject, obj);
+      checkType(subject, rdfClassAnnotation.typesUri()).ifPresent(e -> context.addError(e));
 
-    for (Map.Entry<Field, RdfProperty> entry : annotatedFields.entrySet()) {
-      Field field = entry.getKey();
-      RdfProperty propertyAnnotation = entry.getValue();
+      for (Map.Entry<Field, RdfProperty> entry : annotatedFields.entrySet()) {
+        Field field = entry.getKey();
+        RdfProperty propertyAnnotation = entry.getValue();
 
-      Set<RDFNode> values =
-          listProperties(subject, ResourceFactory.createProperty(propertyAnnotation.uri()));
-      checkCardinalities(subject, propertyAnnotation, values.size())
-          .ifPresent(e -> context.addError(e));
+        Set<RDFNode> values =
+            listProperties(subject, ResourceFactory.createProperty(propertyAnnotation.uri()));
+        checkCardinalities(subject, propertyAnnotation, values.size())
+            .ifPresent(e -> context.addError(e));
 
-      if (field.getType().isAssignableFrom(List.class)) {
-        Class<?> listType =
-            (Class<?>) ((ParameterizedType) field.getGenericType()).getActualTypeArguments()[0];
-        RdfDeserializer<?> elementDeserializer = context.getDeserializer(listType);
-        List<Object> collection = new ArrayList<>();
-        for (RDFNode value : values) {
-          collection.add(elementDeserializer.deserialize(value, context));
-        }
-        setField(field, obj, collection);
-      } else if (!values.isEmpty()) {
-        if (values.size() > 1) {
-          log.warn(
-              "Field '{}' of class '{}' is not a collection, only the first value will be assigned",
-              field.getName(),
-              clazz.getName());
-        }
-
-        RdfDeserializer<?> fieldDeserializer = context.getDeserializer(field.getType());
-        if (field.isAnnotationPresent(RdfDeserialize.class)) {
-          try {
-            fieldDeserializer = createInstance(field.getAnnotation(RdfDeserialize.class).using());
-          } catch (ReflectiveOperationException e) {
-            throw new RdfDeserializationException(
-                String.format("Unable to instantiate custom field deserializer"), e);
+        if (field.getType().isAssignableFrom(List.class)) {
+          Class<?> listType =
+              (Class<?>) ((ParameterizedType) field.getGenericType()).getActualTypeArguments()[0];
+          RdfDeserializer<?> elementDeserializer = context.getDeserializer(listType);
+          List<Object> collection = new ArrayList<>();
+          for (RDFNode value : values) {
+            collection.add(elementDeserializer.deserialize(value, context));
           }
+          setField(field, obj, collection);
+        } else if (!values.isEmpty()) {
+          if (values.size() > 1) {
+            log.warn(
+                "Field '{}' of class '{}' is not a collection, only the first value will be"
+                    + " assigned",
+                field.getName(),
+                clazz.getName());
+          }
+
+          RdfDeserializer<?> fieldDeserializer = context.getDeserializer(field.getType());
+          if (field.isAnnotationPresent(RdfDeserialize.class)) {
+            try {
+              fieldDeserializer = createInstance(field.getAnnotation(RdfDeserialize.class).using());
+            } catch (ReflectiveOperationException e) {
+              throw new RdfDeserializationException(
+                  String.format("Unable to instantiate custom field deserializer"), e);
+            }
+          }
+          Object value = fieldDeserializer.deserialize(values.iterator().next(), context);
+          setField(field, obj, value);
         }
-        Object value = fieldDeserializer.deserialize(values.iterator().next(), context);
-        setField(field, obj, value);
       }
+    } finally {
+      context.popCurrentSubject();
     }
-    context.resetCurrentSubject();
 
     return obj;
   }

--- a/src/main/java/ch/psi/rdf/deser/RdfDeserializationContext.java
+++ b/src/main/java/ch/psi/rdf/deser/RdfDeserializationContext.java
@@ -2,18 +2,32 @@ package ch.psi.rdf.deser;
 
 import ch.psi.ord.model.PropertyError;
 import ch.psi.rdf.RdfDeserializerProvider;
+import java.util.Optional;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.apache.jena.rdf.model.Resource;
+import org.jspecify.annotations.NonNull;
 
 @RequiredArgsConstructor
 public class RdfDeserializationContext {
   private final RdfDeserializerProvider provider;
   private final DeserializationReport<?> report;
+  @Getter private Optional<Resource> currentSubject;
+
+  public Resource setCurrentSubject(@NonNull Resource subject) {
+    currentSubject = Optional.of(subject);
+    return subject;
+  }
+
+  public void resetCurrentSubject() {
+    currentSubject = Optional.empty();
+  }
 
   public void addError(PropertyError e) {
     report.addError(e);
   }
 
-  public RdfDeserializer<?> getDeserializer(Class<?> clazz) throws RdfDeserializationException {
+  public <T> RdfDeserializer<T> getDeserializer(Class<T> clazz) throws RdfDeserializationException {
     return provider.getDeserializer(clazz);
   }
 }

--- a/src/main/java/ch/psi/rdf/deser/RdfDeserializationContext.java
+++ b/src/main/java/ch/psi/rdf/deser/RdfDeserializationContext.java
@@ -2,8 +2,9 @@ package ch.psi.rdf.deser;
 
 import ch.psi.ord.model.PropertyError;
 import ch.psi.rdf.RdfDeserializerProvider;
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.Optional;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.apache.jena.rdf.model.Resource;
 import org.jspecify.annotations.NonNull;
@@ -12,15 +13,19 @@ import org.jspecify.annotations.NonNull;
 public class RdfDeserializationContext {
   private final RdfDeserializerProvider provider;
   private final DeserializationReport<?> report;
-  @Getter private Optional<Resource> currentSubject;
+  private final Deque<Resource> subjects = new ArrayDeque<>();
 
-  public Resource setCurrentSubject(@NonNull Resource subject) {
-    currentSubject = Optional.of(subject);
+  public Optional<Resource> getCurrentSubject() {
+    return Optional.ofNullable(subjects.peek());
+  }
+
+  public Resource pushCurrentSubject(@NonNull Resource subject) {
+    subjects.push(subject);
     return subject;
   }
 
-  public void resetCurrentSubject() {
-    currentSubject = Optional.empty();
+  public void popCurrentSubject() {
+    subjects.pop();
   }
 
   public void addError(PropertyError e) {

--- a/src/main/java/ch/psi/rdf/ser/ObjectSerializer.java
+++ b/src/main/java/ch/psi/rdf/ser/ObjectSerializer.java
@@ -25,43 +25,46 @@ public class ObjectSerializer implements RdfSerializer<Object> {
     Class<?> clazz = value.getClass();
     @NonNull RdfClass rdfClass = validateClassAnnotation(clazz);
     Resource serializedObject =
-        context.setCurrentSubject(createResourceWithUri(value, context.getModel()));
+        context.pushCurrentSubject(createResourceWithUri(value, context.getModel()));
 
-    for (String type : rdfClass.typesUri()) {
-      serializedObject.addProperty(RDF.type, context.getModel().createResource(type));
-    }
-
-    for (Field field : clazz.getDeclaredFields()) {
-      if (!field.isAnnotationPresent(RdfProperty.class)) {
-        continue;
+    try {
+      for (String type : rdfClass.typesUri()) {
+        serializedObject.addProperty(RDF.type, context.getModel().createResource(type));
       }
 
-      try {
-        field.setAccessible(true);
-        Object fieldValue = field.get(value);
-        if (fieldValue == null) {
+      for (Field field : clazz.getDeclaredFields()) {
+        if (!field.isAnnotationPresent(RdfProperty.class)) {
           continue;
         }
-        RdfProperty rdfProperty = field.getAnnotation(RdfProperty.class);
-        Property property = context.getModel().createProperty(rdfProperty.uri());
 
-        RdfSerializer<Object> serializer;
-        if (field.isAnnotationPresent(RdfSerialize.class)) {
-          serializer =
-              (RdfSerializer<Object>)
-                  createInstance(field.getAnnotation(RdfSerialize.class).using());
-        } else {
-          serializer = (RdfSerializer<Object>) context.getSerializer(fieldValue.getClass());
+        try {
+          field.setAccessible(true);
+          Object fieldValue = field.get(value);
+          if (fieldValue == null) {
+            continue;
+          }
+          RdfProperty rdfProperty = field.getAnnotation(RdfProperty.class);
+          Property property = context.getModel().createProperty(rdfProperty.uri());
+
+          RdfSerializer<Object> serializer;
+          if (field.isAnnotationPresent(RdfSerialize.class)) {
+            serializer =
+                (RdfSerializer<Object>)
+                    createInstance(field.getAnnotation(RdfSerialize.class).using());
+          } else {
+            serializer = (RdfSerializer<Object>) context.getSerializer(fieldValue.getClass());
+          }
+          serializer
+              .serialize(fieldValue, context)
+              .forEach(node -> serializedObject.addProperty(property, node));
+        } catch (Exception e) {
+          throw new RdfSerializationException(
+              "An error occured while serializing field " + field.getName(), e);
         }
-        serializer
-            .serialize(fieldValue, context)
-            .forEach(node -> serializedObject.addProperty(property, node));
-      } catch (Exception e) {
-        throw new RdfSerializationException(
-            "An error occured while serializing field " + field.getName(), e);
       }
+    } finally {
+      context.popCurrentSubject();
     }
-    context.resetCurrentSubject();
 
     return List.of(serializedObject);
   }

--- a/src/main/java/ch/psi/rdf/ser/RdfSerializationContext.java
+++ b/src/main/java/ch/psi/rdf/ser/RdfSerializationContext.java
@@ -1,6 +1,8 @@
 package ch.psi.rdf.ser;
 
 import ch.psi.rdf.RdfSerializerProvider;
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.Optional;
 import lombok.Getter;
 import lombok.NonNull;
@@ -10,20 +12,24 @@ import org.apache.jena.rdf.model.Resource;
 
 public class RdfSerializationContext {
   private final RdfSerializerProvider serializerProvider;
-  @Getter private Optional<Resource> currentSubject;
   @Getter Model model = ModelFactory.createDefaultModel();
+  private final Deque<Resource> subjects = new ArrayDeque<>();
 
   public RdfSerializationContext(RdfSerializerProvider serializerProvider) {
     this.serializerProvider = serializerProvider;
   }
 
-  public Resource setCurrentSubject(@NonNull Resource subject) {
-    currentSubject = Optional.of(subject);
+  public Optional<Resource> getCurrentSubject() {
+    return Optional.ofNullable(subjects.peek());
+  }
+
+  public Resource pushCurrentSubject(@NonNull Resource subject) {
+    subjects.push(subject);
     return subject;
   }
 
-  public void resetCurrentSubject() {
-    currentSubject = Optional.empty();
+  public void popCurrentSubject() {
+    subjects.pop();
   }
 
   @SuppressWarnings("unchecked")

--- a/src/test/java/ch/psi/ord/api/EndpointTest.java
+++ b/src/test/java/ch/psi/ord/api/EndpointTest.java
@@ -1,5 +1,7 @@
 package ch.psi.ord.api;
 
+import static org.junit.jupiter.api.Assertions.fail;
+
 import ch.psi.ord.core.RoCrate;
 import ch.psi.s3_broker.client.S3BrokerService;
 import ch.psi.scicat.cli.ScicatCli;
@@ -9,10 +11,16 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.quarkus.test.InjectMock;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.math.BigInteger;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
@@ -49,20 +57,72 @@ public abstract class EndpointTest {
       JsonNode jsonResponse = objectMapper.readTree(response.body());
       return jsonResponse.get("access_token").asText();
     } catch (IOException | InterruptedException e) {
-      throw new RuntimeException("Failed to fetch SciCat access token, aborting tests");
+      fail("Failed to fetch SciCat access token, aborting tests");
+      return "";
     }
   }
 
-  public byte[] zipResource(String name) throws IOException {
-    ByteArrayOutputStream output = new ByteArrayOutputStream();
-    try (ZipOutputStream zipStream = new ZipOutputStream(output)) {
-      ZipEntry entry = new ZipEntry(RoCrate.METADATA_DESCRIPTOR);
-      zipStream.putNextEntry(entry);
-      byte[] content = getClass().getClassLoader().getResourceAsStream(name).readAllBytes();
-      zipStream.write(content, 0, content.length);
-      zipStream.closeEntry();
+  public static byte[] getResource(String resourceName) {
+    try {
+      return EndpointTest.class.getClassLoader().getResourceAsStream(resourceName).readAllBytes();
+    } catch (IOException e) {
+      fail(String.format("Failed to read resource %s", resourceName));
+      return new byte[0];
     }
+  }
 
-    return output.toByteArray();
+  public static byte[] zipResource(String resourceName, Map<String, BigInteger> fileList) {
+    try {
+      ByteArrayOutputStream output = new ByteArrayOutputStream();
+      Random random = new Random();
+      Set<String> createdDirectories = new HashSet<>();
+      try (ZipOutputStream zipStream = new ZipOutputStream(output)) {
+        ZipEntry entry = new ZipEntry(RoCrate.METADATA_DESCRIPTOR);
+        zipStream.putNextEntry(entry);
+        byte[] content = getResource(resourceName);
+        zipStream.write(content, 0, content.length);
+        zipStream.closeEntry();
+
+        for (Map.Entry<String, BigInteger> file : fileList.entrySet()) {
+          createParentDirectories(file.getKey(), zipStream, createdDirectories);
+          zipStream.putNextEntry(new ZipEntry(file.getKey()));
+          byte[] randomBytes = new byte[file.getValue().intValue()];
+          random.nextBytes(randomBytes);
+          zipStream.write(randomBytes);
+          zipStream.closeEntry();
+        }
+      }
+
+      return output.toByteArray();
+    } catch (IOException e) {
+      fail(String.format("Failed to zip resource %s", resourceName));
+      return new byte[0];
+    }
+  }
+
+  public static byte[] zipResource(String resourceName) {
+    return zipResource(resourceName, Collections.emptyMap());
+  }
+
+  private static void createParentDirectories(
+      String filePath, ZipOutputStream zipStream, Set<String> createdDirectories)
+      throws IOException {
+    int lastSlash = filePath.lastIndexOf('/');
+    if (lastSlash != -1) {
+      String dirPath = filePath.substring(0, lastSlash + 1);
+      if (!createdDirectories.contains(dirPath)) {
+        if (dirPath.length() > 1) {
+          String parentDir =
+              dirPath.substring(0, dirPath.lastIndexOf('/', dirPath.length() - 2) + 1);
+          if (!parentDir.isEmpty()) {
+            createParentDirectories(parentDir, zipStream, createdDirectories);
+          }
+        }
+        ZipEntry dirEntry = new ZipEntry(dirPath);
+        zipStream.putNextEntry(dirEntry);
+        zipStream.closeEntry();
+        createdDirectories.add(dirPath);
+      }
+    }
   }
 }

--- a/src/test/java/ch/psi/ord/api/ValidateTest.java
+++ b/src/test/java/ch/psi/ord/api/ValidateTest.java
@@ -1,263 +1,173 @@
 package ch.psi.ord.api;
 
 import static io.restassured.RestAssured.given;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
+import ch.psi.ord.model.ExportFormat;
 import io.quarkus.test.junit.QuarkusTest;
-import java.io.IOException;
+import io.restassured.response.ValidatableResponse;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import lombok.Data;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.FieldSource;
 
 @QuarkusTest
 public class ValidateTest extends EndpointTest {
-  @Test
-  @DisplayName("One publication (ZIP)")
-  public void test00() throws IOException {
-    given()
-        .when()
-        .header("Content-Type", ExtraMediaType.APPLICATION_ZIP)
-        .body(zipResource("one-publication.json"))
-        .post("/api/v1/ro-crate/validate")
-        .then()
-        .statusCode(200)
-        .contentType(is(CONTENT_TYPE_JSON_RES))
-        .body("isValid", is(true))
-        .body("entities", contains("https://doi.org/10.16907/d910159a-d48a-45fb-acf2-74b27cd5a8e5"))
-        .body("errors", emptyIterable());
+  @Data
+  static class ValidateTestCase {
+    String testName;
+    ExportFormat exportFormat;
+    byte[] body;
+    int expectedStatusCode;
+    Consumer<ValidatableResponse> assertions;
+
+    @Override
+    public String toString() {
+      return String.format("[%s] - %s", testName, exportFormat.name());
+    }
   }
 
-  @Test
-  @DisplayName("One publication (JSON-LD)")
-  public void test01() throws IOException {
-    given()
-        .when()
-        .header("Content-Type", ExtraMediaType.APPLICATION_JSONLD)
-        .body(
-            getClass().getClassLoader().getResourceAsStream("one-publication.json").readAllBytes())
-        .post("/api/v1/ro-crate/validate")
-        .then()
-        .statusCode(200)
-        .contentType(is(CONTENT_TYPE_JSON_RES))
-        .body("isValid", is(true))
-        .body("entities", contains("https://doi.org/10.16907/d910159a-d48a-45fb-acf2-74b27cd5a8e5"))
-        .body("errors", emptyIterable());
+  private static List<ValidateTestCase> createTestCase(
+      String testName,
+      String resourceName,
+      int statusCode,
+      Consumer<ValidatableResponse> assertions) {
+    return List.of(
+        new ValidateTestCase()
+            .setTestName(testName)
+            .setExportFormat(ExportFormat.JSONLD)
+            .setBody(getResource(resourceName))
+            .setExpectedStatusCode(statusCode)
+            .setAssertions(assertions),
+        new ValidateTestCase()
+            .setTestName(testName)
+            .setExportFormat(ExportFormat.ZIP)
+            .setBody(zipResource(resourceName))
+            .setExpectedStatusCode(statusCode)
+            .setAssertions(assertions));
   }
 
-  @Test
-  @DisplayName("Multiple publications (JSON-LD)")
-  public void test02() throws IOException {
-    given()
-        .when()
-        .header("Content-Type", ExtraMediaType.APPLICATION_JSONLD)
-        .body(
-            getClass()
-                .getClassLoader()
-                .getResourceAsStream("multiple-publications.json")
-                .readAllBytes())
-        .post("/api/v1/ro-crate/validate")
-        .then()
-        .statusCode(200)
-        .contentType(is(CONTENT_TYPE_JSON_RES))
-        .body("isValid", is(true))
-        .body(
-            "entities",
-            contains(
-                "https://doi.org/10.16907/d910159a-d48a-45fb-acf2-74b27cd5a8e5",
-                "https://doi.org/10.16907/4b55cbae-ac98-445a-a15e-1534b2a8b01f"))
-        .body("errors", emptyIterable());
-  }
+  static List<ValidateTestCase> testMatrix =
+      new ArrayList<>() {
+        {
+          addAll(
+              createTestCase(
+                  "One publication",
+                  "one-publication.json",
+                  200,
+                  res ->
+                      res.body("isValid", is(true))
+                          .body(
+                              "entities",
+                              Matchers.contains(
+                                  "https://doi.org/10.16907/d910159a-d48a-45fb-acf2-74b27cd5a8e5"))
+                          .body("errors", emptyIterable())));
 
-  @Test
-  @DisplayName("Multiple publications (ZIP)")
-  public void test03() throws IOException {
-    given()
-        .when()
-        .header("Content-Type", ExtraMediaType.APPLICATION_ZIP)
-        .body(zipResource("multiple-publications.json"))
-        .post("/api/v1/ro-crate/validate")
-        .then()
-        .statusCode(200)
-        .contentType(is(CONTENT_TYPE_JSON_RES))
-        .body("isValid", is(true))
-        .body(
-            "entities",
-            contains(
-                "https://doi.org/10.16907/d910159a-d48a-45fb-acf2-74b27cd5a8e5",
-                "https://doi.org/10.16907/4b55cbae-ac98-445a-a15e-1534b2a8b01f"))
-        .body("errors", emptyIterable());
-  }
+          addAll(
+              createTestCase(
+                  "Multiple publications",
+                  "multiple-publications.json",
+                  200,
+                  res ->
+                      res.body("isValid", is(true))
+                          .body(
+                              "entities",
+                              Matchers.contains(
+                                  "https://doi.org/10.16907/d910159a-d48a-45fb-acf2-74b27cd5a8e5",
+                                  "https://doi.org/10.16907/4b55cbae-ac98-445a-a15e-1534b2a8b01f"))
+                          .body("errors", emptyIterable())));
 
-  @Test
-  @DisplayName("Publication missing schema:name (JSON-LD)")
-  public void test04() throws IOException {
-    given()
-        .when()
-        .header("Content-Type", ExtraMediaType.APPLICATION_JSONLD)
-        .body(
-            getClass()
-                .getClassLoader()
-                .getResourceAsStream("invalid-publication.json")
-                .readAllBytes())
-        .post("/api/v1/ro-crate/validate")
-        .then()
-        .statusCode(200)
-        .contentType(is(CONTENT_TYPE_JSON_RES))
-        .body("isValid", is(false))
-        .body("entities", emptyIterable())
-        .body("errors", hasSize(1))
-        .body(
-            "errors[0]",
-            hasEntry("nodeId", "https://doi.org/10.16907/d910159a-d48a-45fb-acf2-74b27cd5a8e5"))
-        .body("errors[0]", hasEntry("property", "https://schema.org/name"))
-        .body("errors[0]", hasEntry("message", "Missing required property"))
-        .body("errors[0]", hasEntry("type", "PropertyError"));
-  }
+          addAll(
+              createTestCase(
+                  "Publication missing schema:name",
+                  "invalid-publication.json",
+                  200,
+                  res ->
+                      res.body("isValid", is(false))
+                          .body("entities", emptyIterable())
+                          .body("errors", hasSize(1))
+                          .body(
+                              "errors[0]",
+                              hasEntry(
+                                  "nodeId",
+                                  "https://doi.org/10.16907/d910159a-d48a-45fb-acf2-74b27cd5a8e5"))
+                          .body("errors[0]", hasEntry("property", "https://schema.org/name"))
+                          .body("errors[0]", hasEntry("message", "Missing required property"))
+                          .body("errors[0]", hasEntry("type", "PropertyError"))));
 
-  @Test
-  @DisplayName("Publication missing schema:name (ZIP)")
-  public void test05() throws IOException {
-    given()
-        .when()
-        .header("Content-Type", ExtraMediaType.APPLICATION_ZIP)
-        .body(zipResource("invalid-publication.json"))
-        .post("/api/v1/ro-crate/validate")
-        .then()
-        .statusCode(200)
-        .contentType(is(CONTENT_TYPE_JSON_RES))
-        .body("isValid", is(false))
-        .body("entities", emptyIterable())
-        .body("errors", hasSize(1))
-        .body(
-            "errors[0]",
-            hasEntry("nodeId", "https://doi.org/10.16907/d910159a-d48a-45fb-acf2-74b27cd5a8e5"))
-        .body("errors[0]", hasEntry("property", "https://schema.org/name"))
-        .body("errors[0]", hasEntry("message", "Missing required property"))
-        .body("errors[0]", hasEntry("type", "PropertyError"));
-  }
+          addAll(
+              createTestCase(
+                  "Mix of valid/invalid publications",
+                  "valid-invalid.json",
+                  200,
+                  res ->
+                      res.body("isValid", is(false))
+                          .body(
+                              "entities",
+                              Matchers.contains(
+                                  "https://doi.org/10.16907/4b55cbae-ac98-445a-a15e-1534b2a8b01f"))
+                          .body("errors", hasSize(1))
+                          .body(
+                              "errors[0]",
+                              hasEntry(
+                                  "nodeId",
+                                  "https://doi.org/10.16907/d910159a-d48a-45fb-acf2-74b27cd5a8e5"))
+                          .body("errors[0]", hasEntry("property", "https://schema.org/name"))
+                          .body("errors[0]", hasEntry("message", "Missing required property"))
+                          .body("errors[0]", hasEntry("type", "PropertyError"))));
 
-  @Test
-  @DisplayName("Mix of valid/invalid publications (JSON-LD)")
-  public void test06() throws IOException {
-    given()
-        .when()
-        .header("Content-Type", ExtraMediaType.APPLICATION_JSONLD)
-        .body(getClass().getClassLoader().getResourceAsStream("valid-invalid.json").readAllBytes())
-        .post("/api/v1/ro-crate/validate")
-        .then()
-        .statusCode(200)
-        .contentType(is(CONTENT_TYPE_JSON_RES))
-        .body("isValid", is(false))
-        .body("entities", contains("https://doi.org/10.16907/4b55cbae-ac98-445a-a15e-1534b2a8b01f"))
-        .body("errors", hasSize(1))
-        .body(
-            "errors[0]",
-            hasEntry("nodeId", "https://doi.org/10.16907/d910159a-d48a-45fb-acf2-74b27cd5a8e5"))
-        .body("errors[0]", hasEntry("property", "https://schema.org/name"))
-        .body("errors[0]", hasEntry("message", "Missing required property"))
-        .body("errors[0]", hasEntry("type", "PropertyError"));
-  }
+          addAll(
+              createTestCase(
+                  "Empty graph",
+                  "empty.json",
+                  200,
+                  res ->
+                      res.body("isValid", is(false))
+                          .body("entities", emptyIterable())
+                          .body("errors", hasSize(1))
+                          .body(
+                              "errors[0]",
+                              hasEntry("message", "No suitable entity found in the graph"))
+                          .body("errors[0]", hasEntry("type", "NoEntityFound"))));
 
-  @Test
-  @DisplayName("Mix of valid/invalid publications (ZIP)")
-  public void test07() throws IOException {
-    given()
-        .when()
-        .header("Content-Type", ExtraMediaType.APPLICATION_ZIP)
-        .body(zipResource("valid-invalid.json"))
-        .post("/api/v1/ro-crate/validate")
-        .then()
-        .statusCode(200)
-        .contentType(is(CONTENT_TYPE_JSON_RES))
-        .body("isValid", is(false))
-        .body("entities", contains("https://doi.org/10.16907/4b55cbae-ac98-445a-a15e-1534b2a8b01f"))
-        .body("errors", hasSize(1))
-        .body(
-            "errors[0]",
-            hasEntry("nodeId", "https://doi.org/10.16907/d910159a-d48a-45fb-acf2-74b27cd5a8e5"))
-        .body("errors[0]", hasEntry("property", "https://schema.org/name"))
-        .body("errors[0]", hasEntry("message", "Missing required property"))
-        .body("errors[0]", hasEntry("type", "PropertyError"));
-  }
+          addAll(
+              createTestCase(
+                  "Malformed metadata descriptor",
+                  "malformed.json",
+                  400,
+                  res -> res.body("message", is("Failed to parse the metadata descriptor"))));
 
-  @Test
-  @DisplayName("Empty graph (JSON-LD)")
-  public void test08() throws IOException {
-    given()
-        .when()
-        .header("Content-Type", ExtraMediaType.APPLICATION_JSONLD)
-        .body("{}")
-        .post("/api/v1/ro-crate/validate")
-        .then()
-        .statusCode(200)
-        .contentType(is(CONTENT_TYPE_JSON_RES))
-        .body("isValid", is(false))
-        .body("entities", emptyIterable())
-        .body("errors", hasSize(1))
-        .body("errors[0]", hasEntry("message", "No suitable entity found in the graph"))
-        .body("errors[0]", hasEntry("type", "NoEntityFound"));
-  }
+          add(
+              new ValidateTestCase()
+                  .setTestName("Malformed zip archive")
+                  .setExportFormat(ExportFormat.ZIP)
+                  .setBody(new byte[0])
+                  .setExpectedStatusCode(400)
+                  .setAssertions(res -> res.body("message", is("Invalid or empty zip archive"))));
+        }
+      };
 
-  @Test
-  @DisplayName("Empty graph (ZIP)")
-  public void test09() throws IOException {
-    given()
-        .when()
-        .header("Content-Type", ExtraMediaType.APPLICATION_ZIP)
-        .body(zipResource("empty.json"))
-        .post("/api/v1/ro-crate/validate")
-        .then()
-        .statusCode(200)
-        .contentType(is(CONTENT_TYPE_JSON_RES))
-        .body("isValid", is(false))
-        .body("entities", emptyIterable())
-        .body("errors", hasSize(1))
-        .body("errors[0]", hasEntry("message", "No suitable entity found in the graph"))
-        .body("errors[0]", hasEntry("type", "NoEntityFound"));
-  }
+  @ParameterizedTest
+  @FieldSource("testMatrix")
+  @DisplayName("Validation Matrix Execution")
+  public void testValidationMatrix(ValidateTestCase testCase) {
+    ValidatableResponse response =
+        given()
+            .when()
+            .contentType(testCase.getExportFormat().toString())
+            .body(testCase.getBody())
+            .post("/api/v1/ro-crate/validate")
+            .then()
+            .statusCode(testCase.getExpectedStatusCode())
+            .contentType(is(CONTENT_TYPE_JSON_RES));
 
-  @Test
-  @DisplayName("Malformed metadata descriptor (JSON-LD)")
-  public void test10() throws IOException {
-    given()
-        .when()
-        .header("Content-Type", ExtraMediaType.APPLICATION_JSONLD)
-        .body(getClass().getClassLoader().getResourceAsStream("malformed.json").readAllBytes())
-        .post("/api/v1/ro-crate/validate")
-        .then()
-        .statusCode(400)
-        .contentType(is(CONTENT_TYPE_JSON_RES))
-        .body("message", is("Failed to parse the metadata descriptor"));
-  }
-
-  @Test
-  @DisplayName("Malformed metadata descriptor (ZIP)")
-  public void test11() throws IOException {
-    given()
-        .when()
-        .header("Content-Type", ExtraMediaType.APPLICATION_ZIP)
-        .body(zipResource("malformed.json"))
-        .post("/api/v1/ro-crate/validate")
-        .then()
-        .statusCode(400)
-        .contentType(is(CONTENT_TYPE_JSON_RES))
-        .body("message", is("Failed to parse the metadata descriptor"));
-  }
-
-  @Test
-  @DisplayName("Malformed zip archive (ZIP)")
-  public void test12() throws IOException {
-    given()
-        .when()
-        .header("Content-Type", ExtraMediaType.APPLICATION_ZIP)
-        .body(new byte[0])
-        .post("/api/v1/ro-crate/validate")
-        .then()
-        .statusCode(400)
-        .contentType(is(CONTENT_TYPE_JSON_RES))
-        .body("message", is("Invalid or empty zip archive"));
+    testCase.getAssertions().accept(response);
   }
 }

--- a/src/test/java/ch/psi/ord/core/RoCrateTest.java
+++ b/src/test/java/ch/psi/ord/core/RoCrateTest.java
@@ -1,0 +1,36 @@
+package ch.psi.ord.core;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ch.psi.ord.api.EndpointTest;
+import io.quarkus.test.junit.QuarkusTest;
+import java.io.ByteArrayInputStream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+public class RoCrateTest {
+  @Nested
+  @DisplayName("hasAttachedData")
+  class HasAttachedData {
+    @Test
+    @DisplayName("Metadata descriptor only (JSON-LD)")
+    public void test00() throws Exception {
+      try (RoCrate crate =
+          RoCrate.fromMetadata(new ByteArrayInputStream(EndpointTest.getResource("empty.json")))) {
+        assertFalse(crate.hasAttachedData());
+      }
+    }
+
+    @Test
+    @DisplayName("Zip archive")
+    public void test01() throws Exception {
+      try (RoCrate crate =
+          RoCrate.fromZip(new ByteArrayInputStream(EndpointTest.zipResource("empty.json")))) {
+        assertTrue(crate.hasAttachedData());
+      }
+    }
+  }
+}

--- a/src/test/java/ch/psi/ord/model/PublicationTest.java
+++ b/src/test/java/ch/psi/ord/model/PublicationTest.java
@@ -1,0 +1,155 @@
+package ch.psi.ord.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ch.psi.rdf.RdfMapper;
+import ch.psi.rdf.deser.DeserializationReport;
+import ch.psi.rdf.deser.RdfDeserializationException;
+import io.quarkus.test.junit.QuarkusTest;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFParser;
+import org.apache.jena.vocabulary.SchemaDO;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+public class PublicationTest {
+  private final RdfMapper rdfMapper = new RdfMapper();
+
+  private Resource publication(String hasPart) {
+    String jsonLd =
+        """
+        {
+          "@context": { "@vocab": "https://schema.org/" },
+          "@id": "https://doi.org/10.1234/test",
+          "@type": "Collection",
+          "identifier": "10.1234/test",
+          "creator": {
+            "@id": "https://example.org/person/1",
+            "@type": "Person",
+            "name": "Jane Doe"
+          },
+          "name": "Test publication",
+          "publisher": {
+            "@id": "https://example.org/org/1",
+            "@type": "Organization",
+            "name": "PSI"
+          },
+          "datePublished": "2023-01-01",
+          "abstract": "abstract",
+          "description": "description",
+          "hasPart": %s
+        }
+        """
+            .formatted(hasPart);
+
+    Model model = RDFParser.fromString(jsonLd, Lang.JSONLD11).toModel();
+    return model.createResource("https://doi.org/10.1234/test");
+  }
+
+  @Nested
+  @DisplayName("hasPart")
+  class HasPart {
+    @Test
+    @DisplayName("Only files")
+    public void test00() throws RdfDeserializationException {
+      Resource publication =
+          publication(
+              """
+              {
+                "@id": "file:///data/file.bin",
+                "@type": "MediaObject"
+              }
+              """);
+
+      DeserializationReport<Publication> report =
+          rdfMapper.deserialize(publication, Publication.class);
+
+      assertTrue(report.isValid(), report.toString());
+      assertTrue(report.get().getHasPart().getDatasets().isEmpty());
+      assertEquals(1, report.get().getHasPart().getFiles().size());
+    }
+
+    @Test
+    @DisplayName("Mixed datasets and files")
+    public void test01() throws RdfDeserializationException {
+      Resource publication =
+          publication(
+              """
+              [
+                {
+                  "@id": "https://example.org/dataset/1",
+                  "@type": "Dataset",
+                  "name": "a dataset"
+                },
+                {
+                  "@id": "file:///data/file.bin",
+                  "@type": "MediaObject"
+                }
+              ]
+              """);
+
+      DeserializationReport<Publication> report =
+          rdfMapper.deserialize(publication, Publication.class);
+
+      assertTrue(report.isValid(), report.toString());
+      assertEquals(1, report.get().getHasPart().getDatasets().size());
+      assertEquals(1, report.get().getHasPart().getFiles().size());
+    }
+
+    @Test
+    @DisplayName("File nested behind an intermediate resource")
+    public void test02() throws RdfDeserializationException {
+      Resource publication =
+          publication(
+              """
+              {
+                "@id": "https://example.org/collection/1",
+                "@type": "CreativeWork",
+                "hasPart": {
+                  "@id": "file:///data/nested/file.bin",
+                  "@type": "MediaObject"
+                }
+              }
+              """);
+
+      DeserializationReport<Publication> report =
+          rdfMapper.deserialize(publication, Publication.class);
+
+      assertTrue(report.isValid(), report.toString());
+      assertEquals(1, report.get().getHasPart().getFiles().size());
+    }
+
+    @Test
+    @DisplayName("Subtree without a Dataset or a MediaObject")
+    public void test03() throws RdfDeserializationException {
+      Resource publication =
+          publication(
+              """
+              {
+                "@id": "https://example.org/collection/1",
+                "@type": "CreativeWork"
+              }
+              """);
+
+      DeserializationReport<Publication> report =
+          rdfMapper.deserialize(publication, Publication.class);
+
+      assertFalse(report.isValid());
+      assertTrue(
+          report.getErrors().stream()
+              .anyMatch(
+                  e ->
+                      e.getMessage()
+                          .equals(
+                              String.format(
+                                  "sub-tree should contain at least one '%s' or '%s'",
+                                  SchemaDO.Dataset, SchemaDO.MediaObject))));
+    }
+  }
+}


### PR DESCRIPTION
openBIS doesn't have a concept of dataset like scicat does, only individual files are attached.
This PR implements the validation logic for publications with no dataset in the `hasPart` tree.
For a publication to be valid the tree needs to contain at least one dataset or one file.
