### PR TITLE
fix: introduce maximum processing time for json-ld processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,12 @@ quarkus build -Dquarkus.container-image.push=true
 
 This service can be configured using the following environment variables:
 
-| Name                               | Description                                                  | Default value               |
-|------------------------------------|--------------------------------------------------------------|-----------------------------|
-| `QUARKUS_REST_CLIENT_SCICAT_URL`   | Base URL of the SciCat backend                               | http://backend.localhost    |
-| `QUARKUS_REST_CLIENT_S3BROKER_URL` | Base URL of the S3 Broker                                    | https://s3-broker.localhost |
-| `SCICAT_CLI_PATH`                  | Path of the scicat-cli executable                            | /usr/local/bin/scicat-cli   |
-| `SCICAT_PID_PREFIX`                | PID prefix of the SciCat instance (used to match cli output) | PID.SAMPLE.PREFIX           |
-| `ROCRATE_EXTRACT_DIRECTORY`        | Path where the service extracts crates                       | /rocrate/extract            |
-| `ROCRATE_ARCHIVE_DIRECTORY`        | Path where the service symlinks data for archival            | /rocrate/archive            |
+| Name                               | Description                                                      | Default value               |
+|------------------------------------|------------------------------------------------------------------|-----------------------------|
+| `QUARKUS_REST_CLIENT_SCICAT_URL`   | Base URL of the SciCat backend                                   | http://backend.localhost    |
+| `QUARKUS_REST_CLIENT_S3BROKER_URL` | Base URL of the S3 Broker                                        | https://s3-broker.localhost |
+| `SCICAT_CLI_PATH`                  | Path of the scicat-cli executable                                | /usr/local/bin/scicat-cli   |
+| `SCICAT_PID_PREFIX`                | PID prefix of the SciCat instance (used to match cli output)     | PID.SAMPLE.PREFIX           |
+| `ROCRATE_EXTRACT_DIRECTORY`        | Path where the service extracts crates                           | /rocrate/extract            |
+| `ROCRATE_ARCHIVE_DIRECTORY`        | Path where the service symlinks data for archival                | /rocrate/archive            |
+| `JSONLD_PROCESSING_TIMEOUT`        | Maximum allowed time (in seconds) to process a JSON-LD document. | 10                          |

--- a/src/main/java/ch/psi/ord/api/RoCrateController.java
+++ b/src/main/java/ch/psi/ord/api/RoCrateController.java
@@ -56,6 +56,7 @@ public class RoCrateController {
 
   @ServerExceptionMapper
   public Response mapRiotException(RiotException e) {
+    log.error("Failed to process the crate metadata", e);
     return Response.status(Status.BAD_REQUEST)
         .entity(new Error("Failed to parse the metadata descriptor"))
         .build();

--- a/src/main/java/ch/psi/ord/core/RoCrate.java
+++ b/src/main/java/ch/psi/ord/core/RoCrate.java
@@ -10,6 +10,7 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -39,6 +40,10 @@ public class RoCrate implements AutoCloseable {
       ConfigProvider.getConfig()
           .getOptionalValue("rocrate.extract-directory", String.class)
           .orElse("/rocrate/extract");
+  private static Integer jsonLdTimeout =
+      ConfigProvider.getConfig()
+          .getOptionalValue("jsonld.processing-timeout", Integer.class)
+          .orElse(10);
 
   private Map<String, List<Path>> files =
       Map.of(FILE_KEY, new ArrayList<>(), DIR_KEY, new ArrayList<>());
@@ -57,6 +62,7 @@ public class RoCrate implements AutoCloseable {
     // required to support percent encoded @id's
     // https://github.com/apache/jena/issues/4025
     jsonLdOptions.setUriValidation(UriValidationPolicy.SchemeOnly);
+    jsonLdOptions.setTimeout(Duration.ofSeconds(jsonLdTimeout));
   }
 
   public static RoCrate fromMetadata(InputStream metadataDescriptor)


### PR DESCRIPTION
QA deployment would hang until the reverse proxy timed out as outgoing http requests were blocked.
This will make similar issues easier to troubleshoot in the future.