### PR TITLE
fix: timeout for json-ld document loader

### DIFF
--- a/src/main/java/ch/psi/ord/core/LoggingDocumentLoader.java
+++ b/src/main/java/ch/psi/ord/core/LoggingDocumentLoader.java
@@ -3,6 +3,7 @@ package ch.psi.ord.core;
 import com.apicatalog.jsonld.JsonLdError;
 import com.apicatalog.jsonld.document.Document;
 import com.apicatalog.jsonld.http.DefaultHttpClient;
+import com.apicatalog.jsonld.http.HttpClient;
 import com.apicatalog.jsonld.http.HttpResponse;
 import com.apicatalog.jsonld.loader.DocumentLoader;
 import com.apicatalog.jsonld.loader.DocumentLoaderOptions;
@@ -10,30 +11,33 @@ import com.apicatalog.jsonld.loader.FileLoader;
 import com.apicatalog.jsonld.loader.HttpLoader;
 import com.apicatalog.jsonld.loader.SchemeRouter;
 import java.net.URI;
+import java.time.Duration;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 class LoggingDocumentLoader implements DocumentLoader {
   private final DocumentLoader loader;
 
-  LoggingDocumentLoader() {
-    this(loggingSchemeRouter());
+  LoggingDocumentLoader(Duration timeout) {
+    this(loggingSchemeRouter(timeout));
   }
 
   LoggingDocumentLoader(DocumentLoader delegate) {
     this.loader = delegate;
   }
 
-  private static DocumentLoader loggingSchemeRouter() {
-    DocumentLoader httpLoader = new HttpLoader(LoggingDocumentLoader::send);
+  private static DocumentLoader loggingSchemeRouter(Duration timeout) {
+    HttpClient httpClient = DefaultHttpClient.defaultInstance().timeout(timeout);
+    DocumentLoader httpLoader = new HttpLoader((url, profile) -> send(httpClient, url, profile));
     return new SchemeRouter()
         .set("http", httpLoader)
         .set("https", httpLoader)
         .set("file", new FileLoader());
   }
 
-  private static HttpResponse send(URI url, String requestProfile) throws JsonLdError {
-    HttpResponse response = DefaultHttpClient.defaultInstance().send(url, requestProfile);
+  private static HttpResponse send(HttpClient client, URI url, String requestProfile)
+      throws JsonLdError {
+    HttpResponse response = client.send(url, requestProfile);
     if (response.statusCode() / 100 == 3) {
       log.info("Redirected '{}' -> '{}'", url, response.location().orElse("?"));
     }

--- a/src/main/java/ch/psi/ord/core/RoCrate.java
+++ b/src/main/java/ch/psi/ord/core/RoCrate.java
@@ -48,9 +48,10 @@ public class RoCrate implements AutoCloseable {
       config.getOptionalValue("rocrate.max-path-length", Integer.class).orElse(4096);
   private static final int maxPathSegmentLength =
       config.getOptionalValue("rocrate.max-path-segment-length", Integer.class).orElse(256);
-  private static Integer jsonLdTimeout =
-      config.getOptionalValue("jsonld.processing-timeout", Integer.class).orElse(10);
-  private static final DocumentLoader documentLoader = new LoggingDocumentLoader();
+  private static final Duration jsonLdTimeout =
+      Duration.ofSeconds(
+          config.getOptionalValue("jsonld.processing-timeout", Integer.class).orElse(10));
+  private static final DocumentLoader documentLoader = new LoggingDocumentLoader(jsonLdTimeout);
 
   private Map<String, List<Path>> files =
       Map.of(FILE_KEY, new ArrayList<>(), DIR_KEY, new ArrayList<>());
@@ -69,7 +70,7 @@ public class RoCrate implements AutoCloseable {
     // required to support percent encoded @id's
     // https://github.com/apache/jena/issues/4025
     jsonLdOptions.setUriValidation(UriValidationPolicy.SchemeOnly);
-    jsonLdOptions.setTimeout(Duration.ofSeconds(jsonLdTimeout));
+    jsonLdOptions.setTimeout(jsonLdTimeout);
     jsonLdOptions.setDocumentLoader(documentLoader);
   }
 


### PR DESCRIPTION
The previous timeout setting didn't include fetching remote contexts

> Set a pressing timeout. A processing is eventually terminated after the specified duration. Set null for no timeout. Please note, the timeout does not include time consumed by [DocumentLoader](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).