### PR TITLE
feat: find the root of the crate

### DIFF
--- a/src/main/java/ch/psi/ord/api/RoCrateController.java
+++ b/src/main/java/ch/psi/ord/api/RoCrateController.java
@@ -2,6 +2,7 @@ package ch.psi.ord.api;
 
 import ch.psi.ord.core.DoiUtils;
 import ch.psi.ord.core.RoCrate;
+import ch.psi.ord.core.RoCrateException;
 import ch.psi.ord.core.RoCrateExporter;
 import ch.psi.ord.core.RoCrateImporter;
 import ch.psi.ord.model.Error;
@@ -53,10 +54,16 @@ public class RoCrateController {
 
   @ServerExceptionMapper
   public Response mapRiotException(RiotException e) {
-    log.error("Failed to process the crate metadata", e);
+    log.error("Failed to parse the metadata descriptor", e);
     return Response.status(Status.BAD_REQUEST)
         .entity(new Error("Failed to parse the metadata descriptor"))
         .build();
+  }
+
+  @ServerExceptionMapper
+  public Response mapRoCrateException(RoCrateException e) {
+    log.error("Failed to process the crate", e);
+    return Response.status(422).entity(new Error(e.getMessage())).build();
   }
 
   @ServerExceptionMapper
@@ -149,7 +156,7 @@ public class RoCrateController {
   @Consumes(ExtraMediaType.APPLICATION_JSONLD)
   @Produces(MediaType.APPLICATION_JSON)
   public Response validateCrate(InputStream body)
-      throws RdfDeserializationException, RiotException, IOException {
+      throws RdfDeserializationException, RoCrateException, IOException {
     try (RoCrate crate = RoCrate.fromMetadata(body)) {
       importer.loadCrate(crate);
       return Response.ok(importer.validate()).build();
@@ -161,11 +168,7 @@ public class RoCrateController {
   @Consumes(ExtraMediaType.APPLICATION_ZIP)
   @Produces(MediaType.APPLICATION_JSON)
   public Response validateZippedCrate(InputStream body)
-      throws RiotException,
-          FileNotFoundException,
-          ZipException,
-          IOException,
-          RdfDeserializationException {
+      throws RoCrateException, ZipException, IOException, RdfDeserializationException {
     try (RoCrate crate = RoCrate.fromZip(body)) {
       importer.loadCrate(crate);
       return Response.ok(importer.validate()).build();
@@ -181,7 +184,7 @@ public class RoCrateController {
       @HeaderParam(value = "api-key") String scicatToken,
       @HeaderParam(value = "ownerGroup") String ownerGroup,
       InputStream body)
-      throws RdfDeserializationException, RiotException, IOException {
+      throws RdfDeserializationException, RoCrateException, IOException {
     try (RoCrate crate = RoCrate.fromMetadata(body)) {
       importer.loadCrate(crate);
       ValidationReport report = importer.validate();
@@ -205,11 +208,7 @@ public class RoCrateController {
       @HeaderParam(value = "api-key") String scicatToken,
       @HeaderParam(value = "ownerGroup") String ownerGroup,
       InputStream body)
-      throws RiotException,
-          FileNotFoundException,
-          ZipException,
-          IOException,
-          RdfDeserializationException {
+      throws RoCrateException, ZipException, IOException, RdfDeserializationException {
     try (RoCrate crate = RoCrate.fromZip(body)) {
       importer.loadCrate(crate);
       ValidationReport report = importer.validate();

--- a/src/main/java/ch/psi/ord/core/RoCrate.java
+++ b/src/main/java/ch/psi/ord/core/RoCrate.java
@@ -1,13 +1,18 @@
 package ch.psi.ord.core;
 
+import static ch.psi.rdf.RdfUtils.hasProperty;
+import static ch.psi.rdf.RdfUtils.isOfType;
+import static ch.psi.rdf.RdfUtils.listProperties;
+import static ch.psi.rdf.RdfUtils.listResourcesOfType;
+
 import com.apicatalog.jsonld.JsonLdOptions;
 import com.apicatalog.jsonld.loader.DocumentLoader;
 import com.apicatalog.jsonld.uri.UriValidationPolicy;
 import io.smallrye.config.Config;
 import io.smallrye.config.SmallRyeConfig;
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -20,6 +25,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.zip.ZipException;
 import lombok.Getter;
@@ -28,11 +34,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
 import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFParser;
-import org.apache.jena.riot.RiotException;
 import org.apache.jena.riot.lang.LangJSONLD11;
 import org.apache.jena.sparql.util.Context;
+import org.apache.jena.vocabulary.SchemaDO;
 import org.eclipse.microprofile.config.ConfigProvider;
 
 @Slf4j
@@ -56,6 +64,8 @@ public class RoCrate implements AutoCloseable {
       Map.of(FILE_KEY, new ArrayList<>(), DIR_KEY, new ArrayList<>());
   @Getter private Path base;
   @Getter private Model model;
+  @Getter private Resource metadataDescriptor;
+  @Getter private Resource root;
 
   @Getter
   @Accessors(fluent = true)
@@ -71,8 +81,13 @@ public class RoCrate implements AutoCloseable {
     jsonLdOptions.setDocumentLoader(documentLoader);
   }
 
+  public static RoCrate fromMetadata(String metadata) throws RoCrateException, IOException {
+    return RoCrate.fromMetadata(
+        new ByteArrayInputStream(metadata.getBytes(StandardCharsets.UTF_8)));
+  }
+
   public static RoCrate fromMetadata(InputStream metadataDescriptor)
-      throws RiotException, IOException {
+      throws RoCrateException, IOException {
     RoCrate crate = new RoCrate();
     try {
       crate.createTempDirectory();
@@ -85,7 +100,8 @@ public class RoCrate implements AutoCloseable {
     return crate;
   }
 
-  public static RoCrate fromZip(InputStream zip) throws RiotException, ZipException, IOException {
+  public static RoCrate fromZip(InputStream zip)
+      throws RoCrateException, ZipException, IOException {
     RoCrate crate = new RoCrate();
     try {
       crate.extract(zip);
@@ -185,7 +201,7 @@ public class RoCrate implements AutoCloseable {
     return base.equals(p) || files.get(FILE_KEY).contains(p) || files.get(DIR_KEY).contains(p);
   }
 
-  private void parseMetadataDescriptor(InputStream document) throws RiotException {
+  private void parseMetadataDescriptor(InputStream document) throws RoCrateException {
     model =
         RDFParser.create()
             .source(document)
@@ -194,18 +210,50 @@ public class RoCrate implements AutoCloseable {
             .context(Context.create().set(LangJSONLD11.JSONLD_OPTIONS, jsonLdOptions))
             .build()
             .toModel();
+    findRoot();
   }
 
-  private void readMetadataDescriptor() throws IOException, FileNotFoundException {
+  private void readMetadataDescriptor() throws IOException, RoCrateException {
     Path metadataDescriptor = base.resolve(METADATA_DESCRIPTOR);
     if (!metadataDescriptor.toFile().exists()) {
-      throw new FileNotFoundException(
+      throw new RoCrateException(
           String.format("Archive doesn't contain a \"%s\" file", METADATA_DESCRIPTOR));
     }
 
     try (InputStream content = new FileInputStream(metadataDescriptor.toFile())) {
       parseMetadataDescriptor(content);
     }
+  }
+
+  // https://www.researchobject.org/ro-crate/specification/1.3/appendix/relative-uris#finding-ro-crate-root-in-rdf-triple-stores
+  private Resource findRoot() throws RoCrateException {
+    Set<Resource> metadataDescriptor =
+        listResourcesOfType(
+            model,
+            SchemaDO.CreativeWork,
+            subject ->
+                subject.toString().endsWith(METADATA_DESCRIPTOR)
+                    && hasProperty(subject, SchemaDO.about));
+
+    if (metadataDescriptor.size() != 1) {
+      throw new RoCrateException(
+          "Expected exactly one metadata descriptor, but found " + metadataDescriptor.size());
+    }
+
+    this.metadataDescriptor = metadataDescriptor.iterator().next();
+
+    Set<RDFNode> root =
+        listProperties(
+            this.metadataDescriptor,
+            SchemaDO.about,
+            node -> node.isResource() && isOfType(node.asResource(), SchemaDO.Dataset));
+
+    if (root.size() != 1) {
+      throw new RoCrateException("Expected exactly one root dataset, but found " + root.size());
+    }
+
+    this.root = root.iterator().next().asResource();
+    return this.root;
   }
 
   public String toRelativeId(String absoluteId) {

--- a/src/main/java/ch/psi/ord/core/RoCrateException.java
+++ b/src/main/java/ch/psi/ord/core/RoCrateException.java
@@ -1,0 +1,11 @@
+package ch.psi.ord.core;
+
+public class RoCrateException extends Exception {
+  public RoCrateException(String message) {
+    super(message);
+  }
+
+  public RoCrateException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/main/java/ch/psi/rdf/RdfUtils.java
+++ b/src/main/java/ch/psi/rdf/RdfUtils.java
@@ -104,6 +104,16 @@ public class RdfUtils {
         .toSet();
   }
 
+  public static Set<RDFNode> listProperties(
+      Resource subject, Property p, Predicate<RDFNode> predicate) {
+    return subject
+        .getModel()
+        .listObjectsOfProperty(subject, p)
+        .andThen(subject.getModel().listObjectsOfProperty(subject, switchScheme(p)))
+        .filterKeep(predicate)
+        .toSet();
+  }
+
   public static Set<Resource> listResourcesOfType(Model model, Resource type) {
     return model
         .listResourcesWithProperty(RDF.type, type)

--- a/src/test/java/ch/psi/ord/api/ImportTest.java
+++ b/src/test/java/ch/psi/ord/api/ImportTest.java
@@ -183,7 +183,7 @@ public class ImportTest extends EndpointTest {
                   ExtraMediaType.APPLICATION_JSONLD,
                   true,
                   "{}".getBytes(),
-                  400,
+                  422,
                   checkTokenValidity(true),
                   NO_ASSERTIONS));
 

--- a/src/test/java/ch/psi/ord/core/RoCrateTest.java
+++ b/src/test/java/ch/psi/ord/core/RoCrateTest.java
@@ -137,15 +137,67 @@ public class RoCrateTest {
   public void test00() throws Exception {
     try (RoCrate crate =
         RoCrate.fromMetadata(
-            new ByteArrayInputStream(
-                """
-                  {
-                     "@id": "percent%20encoded%filename",
-                     "@type": "http://schema.org/Dataset"
-                  }
-                """
-                    .getBytes()))) {
-      assertEquals(1, crate.getModel().listSubjects().toList().size());
+"""
+{
+  "@context": "https://w3id.org/ro/crate/1.1/context",
+  "@graph": [
+    {
+      "@type": "CreativeWork",
+      "@id": "ro-crate-metadata.json",
+      "conformsTo": { "@id": "https://w3id.org/ro/crate/1.1" },
+      "about": { "@id": "./" }
+    },
+    {
+      "@id": "./",
+      "@type": "Dataset",
+      "hasPart": [ { "@id": "percent%20encoded%20filename" } ]
+    },
+    {
+      "@id": "percent%20encoded%20filename",
+      "@type": "Dataset"
+    }
+  ]
+}
+""")) {
+      assertEquals(3, crate.getModel().listSubjects().toList().size());
+    }
+  }
+
+  @Nested
+  @DisplayName("Root discovery")
+  class RootDiscovery {
+    @Test
+    @DisplayName("The metadata descriptor and the root dataset are identified")
+    public void test00() throws Exception {
+      try (RoCrate crate =
+          RoCrate.fromMetadata(
+"""
+{
+  "@graph": [
+    {
+      "@id": "ro-crate-metadata.json",
+      "@type": "http://schema.org/CreativeWork",
+      "http://schema.org/about": { "@id": "./" }
+    },
+    {
+      "@id": "./",
+      "@type": "http://schema.org/Dataset"
+    }
+  ]
+}
+""")) {
+        assertTrue(
+            crate.getMetadataDescriptor().getURI().endsWith(RoCrate.METADATA_DESCRIPTOR),
+            String.format("Unexpected metadata descriptor: %s", crate.getMetadataDescriptor()));
+        assertEquals(crate.getBase().toUri().toString(), crate.getRoot().getURI());
+      }
+    }
+
+    @Test
+    @DisplayName("A crate without a root is rejected")
+    public void test01() {
+      RoCrateException e = assertThrows(RoCrateException.class, () -> RoCrate.fromMetadata("{ }"));
+      assertEquals("Expected exactly one metadata descriptor, but found 0", e.getMessage());
     }
   }
 }

--- a/src/test/resources/empty.json
+++ b/src/test/resources/empty.json
@@ -1,1 +1,16 @@
-{ }
+{
+  "@context": "https://w3id.org/ro/crate/1.1/context",
+  "@graph": [
+    {
+      "@type": "CreativeWork",
+      "@id": "ro-crate-metadata.json",
+      "conformsTo": { "@id": "https://w3id.org/ro/crate/1.1" },
+      "about": { "@id": "./" }
+    },
+
+    {
+      "@id": "./",
+      "@type": "Dataset"
+    }
+  ]
+}


### PR DESCRIPTION
A valid crate needs a root dataset and an entry for the metadata descriptor.
The parsing should walk the `hasPart` tree from the root to find importable Dataset/Publication.