### PR TITLE
refactor: use the root to validate entries

### DIFF
--- a/src/main/java/ch/psi/ord/core/RoCrateImporter.java
+++ b/src/main/java/ch/psi/ord/core/RoCrateImporter.java
@@ -5,10 +5,10 @@ import static ch.psi.rdf.RdfUtils.listResourcesOfType;
 import ch.psi.ord.model.MissingDataError;
 import ch.psi.ord.model.NoEntityFound;
 import ch.psi.ord.model.Publication;
+import ch.psi.ord.model.RootDataset;
 import ch.psi.ord.model.ValidationReport;
 import ch.psi.ord.model.ValidationReport.Entity;
 import ch.psi.rdf.RdfMapper;
-import ch.psi.rdf.deser.DeserializationReport;
 import ch.psi.rdf.deser.RdfDeserializationException;
 import ch.psi.scicat.cli.ScicatCli;
 import ch.psi.scicat.client.ScicatService;
@@ -221,19 +221,28 @@ public class RoCrateImporter {
       report.getErrors().addAll(dataErrors);
     }
 
-    List<Resource> potentialPublications = listPublications();
-    if (potentialPublications.isEmpty()) {
+    RootDataset rootDataset =
+        rdfMapper
+            .deserialize(inferredModel.getResource(crate.getRoot().getURI()), RootDataset.class)
+            .get();
+
+    if (rootDataset.isEmpty()) {
       report.addError(new NoEntityFound());
       return report;
     }
 
-    for (Resource r : potentialPublications) {
-      var subreport = validatePublication(r);
-      if (subreport.isValid()) {
-        Publication p = subreport.get();
-        report.addEntity(new Entity<>(crate.toRelativeId(p.getResourceIdentifier()), p));
-      } else {
-        report.getErrors().addAll(subreport.getErrors());
+    for (Map.Entry<Class<?>, Set<Resource>> entry : rootDataset.getHasPart().entrySet()) {
+      Class<?> targetClass = entry.getKey();
+      Set<Resource> resources = entry.getValue();
+
+      for (Resource r : resources) {
+        var subreport = rdfMapper.deserialize(r, targetClass);
+        if (subreport.isValid()) {
+          String id = crate.toRelativeId(r.toString());
+          report.addEntity(new Entity<>(id, subreport.get()));
+        } else {
+          report.getErrors().addAll(subreport.getErrors());
+        }
       }
     }
 
@@ -272,15 +281,5 @@ public class RoCrateImporter {
         });
 
     return errors;
-  }
-
-  public List<Resource> listPublications() {
-    return new ArrayList<>(
-        listResourcesOfType(this.inferredModel, SchemaDO.Collection, (subject) -> true));
-  }
-
-  public DeserializationReport<Publication> validatePublication(Resource subject)
-      throws RdfDeserializationException {
-    return rdfMapper.deserialize(subject, Publication.class);
   }
 }

--- a/src/main/java/ch/psi/ord/model/RootDataset.java
+++ b/src/main/java/ch/psi/ord/model/RootDataset.java
@@ -1,0 +1,71 @@
+package ch.psi.ord.model;
+
+import static ch.psi.rdf.RdfUtils.isOfType;
+import static ch.psi.rdf.RdfUtils.listProperties;
+
+import ch.psi.ord.model.RootDataset.RootDatasetDeserializer;
+import ch.psi.rdf.annotations.RdfClass;
+import ch.psi.rdf.annotations.RdfDeserialize;
+import ch.psi.rdf.deser.RdfDeserializationContext;
+import ch.psi.rdf.deser.RdfDeserializationException;
+import ch.psi.rdf.deser.RdfDeserializer;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.vocabulary.SchemaDO;
+
+@Slf4j
+@RdfClass(typesUri = SchemaDO.NS + "Dataset")
+@RdfDeserialize(using = RootDatasetDeserializer.class)
+public class RootDataset {
+  @Getter
+  HashMap<Class<?>, Set<Resource>> hasPart =
+      new HashMap<>(
+          Map.of(
+              Publication.class, new HashSet<>(),
+              Dataset.class, new HashSet<>()));
+
+  public boolean isEmpty() {
+    return hasPart.values().stream().allMatch(set -> set.isEmpty());
+  }
+
+  public static class RootDatasetDeserializer implements RdfDeserializer<RootDataset> {
+    @Override
+    public RootDataset deserialize(RDFNode node, RdfDeserializationContext context)
+        throws RdfDeserializationException {
+      RootDataset result = new RootDataset();
+      walkHasPartTree(result, node.asResource(), new HashSet<>());
+
+      return result;
+    }
+
+    private void walkHasPartTree(RootDataset result, Resource subject, Set<Resource> visited) {
+      if (!visited.add(subject)) {
+        log.warn("Skipping cyclic reference to '{}'", subject);
+        return;
+      }
+
+      Set<Resource> parts =
+          listProperties(subject, SchemaDO.hasPart).stream()
+              .filter(node -> node.isResource())
+              .map(node -> node.asResource())
+              .collect(Collectors.toSet());
+
+      for (Resource r : parts) {
+        if (isOfType(r, SchemaDO.Collection)) {
+          result.hasPart.get(Publication.class).add(r);
+        } else if (isOfType(r, SchemaDO.Dataset)) {
+          result.hasPart.get(Dataset.class).add(r);
+        } else {
+          walkHasPartTree(result, r, visited);
+        }
+      }
+    }
+  }
+}

--- a/src/test/java/ch/psi/ord/api/ValidateTest.java
+++ b/src/test/java/ch/psi/ord/api/ValidateTest.java
@@ -3,6 +3,7 @@ package ch.psi.ord.api;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
@@ -111,7 +112,7 @@ public class ValidateTest extends EndpointTest {
                       res.body("isValid", is(false))
                           .body(
                               "entities",
-                              Matchers.contains(
+                              hasItem(
                                   "https://doi.org/10.16907/4b55cbae-ac98-445a-a15e-1534b2a8b01f"))
                           .body("errors", hasSize(1))
                           .body(

--- a/src/test/java/ch/psi/ord/core/RoCrateImporterTest.java
+++ b/src/test/java/ch/psi/ord/core/RoCrateImporterTest.java
@@ -4,11 +4,6 @@ import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
-import org.apache.jena.rdf.model.Property;
-import org.apache.jena.rdf.model.ResourceFactory;
-import org.apache.jena.vocabulary.OWL;
-import org.apache.jena.vocabulary.SchemaDO;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -31,80 +26,6 @@ public class RoCrateImporterTest {
     @DisplayName("Null model")
     public void test00() {
       importer.loadModel(null);
-    }
-  }
-
-  @Nested
-  @DisplayName("listPublications")
-  class ListCreativeWorks {
-    static final String validDoi = "10.123/abc123";
-    static final String invalidDoi = "20.123/abc123";
-
-    @Test
-    @DisplayName("Empty graph")
-    public void test01() {
-      Assertions.assertEquals(0, importer.listPublications().size());
-    }
-
-    @Test
-    @DisplayName("One Publication")
-    public void test02() {
-      m.createResource(SchemaDO.Collection).addProperty(SchemaDO.identifier, validDoi);
-
-      importer.loadModel(m);
-      Assertions.assertEquals(1, importer.listPublications().size());
-    }
-
-    @Test
-    @DisplayName("Equivalent property")
-    public void test05() {
-      Property identifierEquivalent = m.createProperty("http://example.org/id");
-      m.add(identifierEquivalent, OWL.equivalentProperty, SchemaDO.identifier);
-      m.createResource(SchemaDO.Collection).addProperty(identifierEquivalent, validDoi);
-
-      importer.loadModel(m);
-      Assertions.assertEquals(1, importer.listPublications().size());
-    }
-
-    @Test
-    @DisplayName("Multiple Publications")
-    public void test07() {
-      for (int i = 0; i < 5; i++) {
-        m.createResource(SchemaDO.Collection).addProperty(SchemaDO.identifier, validDoi + i);
-      }
-
-      importer.loadModel(m);
-      Assertions.assertEquals(5, importer.listPublications().size());
-    }
-
-    @Test
-    @DisplayName("Http type")
-    public void test08() {
-      m.createResource(ResourceFactory.createResource("http://schema.org/Collection"))
-          .addProperty(SchemaDO.identifier, validDoi);
-
-      importer.loadModel(m);
-      Assertions.assertEquals(1, importer.listPublications().size());
-    }
-
-    @Test
-    @DisplayName("Http identifier")
-    public void test09() {
-      m.createResource(SchemaDO.Collection)
-          .addProperty(ResourceFactory.createProperty("http://schema.org/identifier"), validDoi);
-
-      importer.loadModel(m);
-      Assertions.assertEquals(1, importer.listPublications().size());
-    }
-
-    @Test
-    @DisplayName("Http type and identifier")
-    public void test10() {
-      m.createResource(ResourceFactory.createResource("http://schema.org/Collection"))
-          .addProperty(ResourceFactory.createProperty("http://schema.org/identifier"), validDoi);
-
-      importer.loadModel(m);
-      Assertions.assertEquals(1, importer.listPublications().size());
     }
   }
 }

--- a/src/test/java/ch/psi/ord/model/RootDatasetTest.java
+++ b/src/test/java/ch/psi/ord/model/RootDatasetTest.java
@@ -1,0 +1,194 @@
+package ch.psi.ord.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ch.psi.rdf.RdfMapper;
+import ch.psi.rdf.deser.DeserializationReport;
+import ch.psi.rdf.deser.RdfDeserializationException;
+import io.quarkus.test.junit.QuarkusTest;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFParser;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+public class RootDatasetTest {
+  private static final String ROOT_ID = "https://example.org/crate/";
+
+  private final RdfMapper rdfMapper = new RdfMapper();
+
+  private RootDataset deserialize(String jsonLd) throws RdfDeserializationException {
+    Model model = RDFParser.fromString(jsonLd, Lang.JSONLD11).toModel();
+    DeserializationReport<RootDataset> report =
+        rdfMapper.deserialize(model.createResource(ROOT_ID), RootDataset.class);
+    assertTrue(report.isValid(), report.toString());
+
+    return report.get();
+  }
+
+  private Set<String> ids(RootDataset rootDataset, Class<?> type) {
+    return rootDataset.getHasPart().get(type).stream()
+        .map(Resource::toString)
+        .collect(Collectors.toSet());
+  }
+
+  @Test
+  @DisplayName("Root without hasPart is empty")
+  public void test00() throws RdfDeserializationException {
+    RootDataset rootDataset =
+        deserialize(
+            """
+            {
+              "@context": { "@vocab": "https://schema.org/" },
+              "@graph": [
+                {
+                  "@id": "https://example.org/crate/",
+                  "@type": "Dataset",
+                  "hasPart": []
+                }
+              ]
+            }
+            """);
+
+    assertTrue(rootDataset.isEmpty());
+  }
+
+  @Test
+  @DisplayName("Collections and Datasets are collected separately")
+  public void test01() throws RdfDeserializationException {
+    RootDataset rootDataset =
+        deserialize(
+            """
+            {
+              "@context": { "@vocab": "https://schema.org/" },
+              "@graph": [
+                {
+                  "@id": "https://example.org/crate/",
+                  "@type": "Dataset",
+                  "hasPart": [
+                    { "@id": "https://doi.org/10.1234/pub1" },
+                    { "@id": "https://example.org/ds1" }
+                  ]
+                },
+                {
+                  "@id": "https://doi.org/10.1234/pub1",
+                  "@type": "Collection"
+                },
+                {
+                  "@id": "https://example.org/ds1",
+                  "@type": "Dataset"
+                }
+              ]
+            }
+            """);
+
+    assertEquals(Set.of("https://doi.org/10.1234/pub1"), ids(rootDataset, Publication.class));
+    assertEquals(Set.of("https://example.org/ds1"), ids(rootDataset, Dataset.class));
+  }
+
+  @Test
+  @DisplayName("Entities behind an intermediate node are collected")
+  public void test02() throws RdfDeserializationException {
+    RootDataset rootDataset =
+        deserialize(
+            """
+            {
+              "@context": { "@vocab": "https://schema.org/" },
+              "@graph": [
+                {
+                  "@id": "https://example.org/crate/",
+                  "@type": "Dataset",
+                  "hasPart": [{ "@id": "https://example.org/group" }]
+                },
+                {
+                  "@id": "https://example.org/group",
+                  "@type": "CreativeWork",
+                  "hasPart": [{ "@id": "https://doi.org/10.1234/pub1" }]
+                },
+                {
+                  "@id": "https://doi.org/10.1234/pub1",
+                  "@type": "Collection"
+                }
+              ]
+            }
+            """);
+
+    assertEquals(Set.of("https://doi.org/10.1234/pub1"), ids(rootDataset, Publication.class));
+  }
+
+  @Test
+  @DisplayName("The parts of a Publication are not collected as top level entities")
+  public void test03() throws RdfDeserializationException {
+    RootDataset rootDataset =
+        deserialize(
+            """
+            {
+              "@context": { "@vocab": "https://schema.org/" },
+              "@graph": [
+                {
+                  "@id": "https://example.org/crate/",
+                  "@type": "Dataset",
+                  "hasPart": [{ "@id": "https://doi.org/10.1234/pub1" }]
+                },
+                {
+                  "@id": "https://doi.org/10.1234/pub1",
+                  "@type": "Collection",
+                  "hasPart": [{ "@id": "https://example.org/ds1" }]
+                },
+                {
+                  "@id": "https://example.org/ds1",
+                  "@type": "Dataset"
+                }
+              ]
+            }
+            """);
+
+    assertEquals(Set.of("https://doi.org/10.1234/pub1"), ids(rootDataset, Publication.class));
+    assertTrue(
+        rootDataset.getHasPart().get(Dataset.class).isEmpty(),
+        "Datasets of a Publication must be imported through that Publication");
+  }
+
+  @Test
+  @DisplayName("A cycle in the hasPart tree terminates")
+  public void test04() throws RdfDeserializationException {
+    RootDataset rootDataset =
+        deserialize(
+            """
+            {
+              "@context": { "@vocab": "https://schema.org/" },
+              "@graph": [
+                {
+                  "@id": "https://example.org/crate/",
+                  "@type": "Dataset",
+                  "hasPart": [{ "@id": "https://example.org/a" }]
+                },
+                {
+                  "@id": "https://example.org/a",
+                  "@type": "CreativeWork",
+                  "hasPart": [{ "@id": "https://example.org/b" }]
+                },
+                {
+                  "@id": "https://example.org/b",
+                  "@type": "CreativeWork",
+                  "hasPart": [
+                    { "@id": "https://example.org/a" },
+                    { "@id": "https://doi.org/10.1234/pub1" }
+                  ]
+                },
+                {
+                  "@id": "https://doi.org/10.1234/pub1",
+                  "@type": "Collection"
+                }
+              ]
+            }
+            """);
+
+    assertEquals(Set.of("https://doi.org/10.1234/pub1"), ids(rootDataset, Publication.class));
+  }
+}

--- a/src/test/resources/invalid-publication.json
+++ b/src/test/resources/invalid-publication.json
@@ -38,18 +38,7 @@
             },
             "datePublished": "2023-01-01",
             "hasPart": [
-                {
-                    "@id": "https://dacat-development.psi.ch/datasets/PID.SAMPLE.PREFIX%2Fmaxiv_ds2"
-                },
-                {
-                    "@id": "https://doi.org/10.16907/d910159a-d48a-45fb-acf2-74b27cd5a8e5"
-                },
-                {
-                    "@id": "https://dacat-development.psi.ch/datasets/PID.SAMPLE.PREFIX%2Fsoleil_ds2"
-                },
-                {
-                    "@id": "https://dacat-development.psi.ch/datasets/PID.SAMPLE.PREFIX%2Fukri_ds5"
-                }
+                { "@id": "https://doi.org/10.16907/d910159a-d48a-45fb-acf2-74b27cd5a8e5" }
             ]
         },
         {

--- a/src/test/resources/multiple-publications.json
+++ b/src/test/resources/multiple-publications.json
@@ -38,24 +38,8 @@
       },
       "datePublished": "2023-01-01",
       "hasPart": [
-        {
-          "@id": "https://dacat-development.psi.ch/datasets/PID.SAMPLE.PREFIX%2Fmaxiv_ds2"
-        },
-        {
-          "@id": "https://doi.org/10.16907/d910159a-d48a-45fb-acf2-74b27cd5a8e5"
-        },
-        {
-          "@id": "https://dacat-development.psi.ch/datasets/PID.SAMPLE.PREFIX%2Fsoleil_ds2"
-        },
-        {
-          "@id": "https://dacat-development.psi.ch/datasets/PID.SAMPLE.PREFIX%2Fukri_ds5"
-        },
-        {
-          "@id": "https://dacat-development.psi.ch/datasets/PID.SAMPLE.PREFIX%2Fdesy_ds2"
-        },
-        {
-          "@id": "https://doi.org/10.16907/4b55cbae-ac98-445a-a15e-1534b2a8b01f"
-        }
+        { "@id": "https://doi.org/10.16907/d910159a-d48a-45fb-acf2-74b27cd5a8e5" },
+        { "@id": "https://doi.org/10.16907/4b55cbae-ac98-445a-a15e-1534b2a8b01f" }
       ]
     },
     {

--- a/src/test/resources/one-publication.json
+++ b/src/test/resources/one-publication.json
@@ -38,18 +38,7 @@
             },
             "datePublished": "2023-01-01",
             "hasPart": [
-                {
-                    "@id": "https://dacat-development.psi.ch/datasets/PID.SAMPLE.PREFIX%2Fmaxiv_ds2"
-                },
-                {
-                    "@id": "https://doi.org/10.16907/d910159a-d48a-45fb-acf2-74b27cd5a8e5"
-                },
-                {
-                    "@id": "https://dacat-development.psi.ch/datasets/PID.SAMPLE.PREFIX%2Fsoleil_ds2"
-                },
-                {
-                    "@id": "https://dacat-development.psi.ch/datasets/PID.SAMPLE.PREFIX%2Fukri_ds5"
-                }
+                { "@id": "https://doi.org/10.16907/d910159a-d48a-45fb-acf2-74b27cd5a8e5" }
             ]
         },
         {

--- a/src/test/resources/valid-invalid.json
+++ b/src/test/resources/valid-invalid.json
@@ -39,19 +39,7 @@
       "datePublished": "2023-01-01",
       "hasPart": [
         {
-          "@id": "https://dacat-development.psi.ch/datasets/PID.SAMPLE.PREFIX%2Fmaxiv_ds2"
-        },
-        {
           "@id": "https://doi.org/10.16907/d910159a-d48a-45fb-acf2-74b27cd5a8e5"
-        },
-        {
-          "@id": "https://dacat-development.psi.ch/datasets/PID.SAMPLE.PREFIX%2Fsoleil_ds2"
-        },
-        {
-          "@id": "https://dacat-development.psi.ch/datasets/PID.SAMPLE.PREFIX%2Fukri_ds5"
-        },
-        {
-          "@id": "https://dacat-development.psi.ch/datasets/PID.SAMPLE.PREFIX%2Fdesy_ds2"
         },
         {
           "@id": "https://doi.org/10.16907/4b55cbae-ac98-445a-a15e-1534b2a8b01f"


### PR DESCRIPTION
Validates `schema:Collection` and `schema:Dataset`