### PR TITLE
fix: move files to archive location

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,14 @@ quarkus build -Dquarkus.container-image.push=true
 
 This service can be configured using the following environment variables:
 
-| Name                               | Description                                                        | Default value               |
-|------------------------------------|--------------------------------------------------------------------|-----------------------------|
-| `QUARKUS_REST_CLIENT_SCICAT_URL`   | Base URL of the SciCat backend                                     | http://backend.localhost    |
-| `QUARKUS_REST_CLIENT_S3BROKER_URL` | Base URL of the S3 Broker                                          | https://s3-broker.localhost |
-| `SCICAT_CLI_PATH`                  | Path of the scicat-cli executable                                  | /usr/local/bin/scicat-cli   |
-| `SCICAT_PID_PREFIX`                | PID prefix of the SciCat instance (used to match cli output)       | PID.SAMPLE.PREFIX           |
-| `ROCRATE_EXTRACT_DIRECTORY`        | Path where the service extracts crates                             | /rocrate/extract            |
-| `ROCRATE_ARCHIVE_DIRECTORY`        | Path where the service symlinks data for archival                  | /rocrate/archive            |
-| `ROCRATE_MAX_PATH_LENGTH`          | Maximum length (in bytes) of an extracted path                     | 4096                        |
-| `ROCRATE_MAX_PATH_SEGMENT_LENGTH`  | Maximum length (in bytes) of a single segment of an extracted path | 256                         |
-| `JSONLD_PROCESSING_TIMEOUT`        | Maximum allowed time (in seconds) to process a JSON-LD document.   | 10                          |
+| Name                               | Description                                                                                              | Default value               |
+|------------------------------------|----------------------------------------------------------------------------------------------------------|-----------------------------|
+| `QUARKUS_REST_CLIENT_SCICAT_URL`   | Base URL of the SciCat backend                                                                           | http://backend.localhost    |
+| `QUARKUS_REST_CLIENT_S3BROKER_URL` | Base URL of the S3 Broker                                                                                | https://s3-broker.localhost |
+| `SCICAT_CLI_PATH`                  | Path of the scicat-cli executable                                                                        | /usr/local/bin/scicat-cli   |
+| `SCICAT_PID_PREFIX`                | PID prefix of the SciCat instance (used to match cli output)                                             | PID.SAMPLE.PREFIX           |
+| `ROCRATE_EXTRACT_DIRECTORY`        | Path where the service extracts crates                                                                   | /rocrate/extract            |
+| `ROCRATE_ARCHIVE_DIRECTORY`        | Path where the service moves data for archival (must be on the same filesystem as the extract directory) | /rocrate/archive            |
+| `ROCRATE_MAX_PATH_LENGTH`          | Maximum length (in bytes) of an extracted path                                                           | 4096                        |
+| `ROCRATE_MAX_PATH_SEGMENT_LENGTH`  | Maximum length (in bytes) of a single segment of an extracted path                                       | 256                         |
+| `JSONLD_PROCESSING_TIMEOUT`        | Maximum allowed time (in seconds) to process a JSON-LD document.                                         | 10                          |

--- a/src/main/java/ch/psi/ord/core/RoCrate.java
+++ b/src/main/java/ch/psi/ord/core/RoCrate.java
@@ -23,7 +23,6 @@ import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.zip.ZipException;
 import lombok.Getter;
-import lombok.Setter;
 import lombok.experimental.Accessors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
@@ -61,8 +60,6 @@ public class RoCrate implements AutoCloseable {
   @Getter
   @Accessors(fluent = true)
   private boolean hasAttachedData = false;
-
-  @Getter @Setter private boolean scheduledForArchival = false;
 
   private JsonLdOptions jsonLdOptions = new JsonLdOptions();
 
@@ -157,13 +154,6 @@ public class RoCrate implements AutoCloseable {
   @Override
   public void close() {
     if (base == null || !Files.exists(base)) {
-      return;
-    }
-
-    if (scheduledForArchival) {
-      log.info(
-          "Crate at '{}' is scheduled for archival, skipping filesystem cleanup",
-          base.toAbsolutePath());
       return;
     }
 

--- a/src/main/java/ch/psi/ord/core/RoCrateImporter.java
+++ b/src/main/java/ch/psi/ord/core/RoCrateImporter.java
@@ -134,7 +134,6 @@ public class RoCrateImporter {
 
   private void scheduleForArchival(String pid) {
     datasetsToArchive.add(pid);
-    crate.setScheduledForArchival(true);
   }
 
   public void importPublication(

--- a/src/main/java/ch/psi/scicat/cli/ScicatCli.java
+++ b/src/main/java/ch/psi/scicat/cli/ScicatCli.java
@@ -5,23 +5,30 @@ import ch.psi.scicat.model.v3.CreateDatasetDto;
 import ch.psi.scicat.model.v3.DatasetLifeCycle;
 import ch.psi.scicat.model.v3.UpdateDatasetDto;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.runtime.Startup;
+import io.quarkus.runtime.configuration.ConfigurationException;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.file.FileStore;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
 @Slf4j
+@Startup
 @ApplicationScoped
 public class ScicatCli {
   @Inject private ObjectMapper mapper;
@@ -42,11 +49,30 @@ public class ScicatCli {
       @ConfigProperty(name = "scicat.pid-prefix", defaultValue = "PID.SAMPLE.PREFIX")
           String pidPrefix,
       @ConfigProperty(name = "rocrate.archive-directory", defaultValue = "/rocrate/archive")
-          String archiveDirectory) {
+          String archiveDirectory,
+      @ConfigProperty(name = "rocrate.extract-directory", defaultValue = "/rocrate/extract")
+          String extractDirectory) {
     Path p = Path.of(cliPath);
     if (Files.isDirectory(p) || !Files.isExecutable(p)) {
-      throw new IllegalStateException(
+      throw new ConfigurationException(
           String.format("scicat-cli binary not found or not executable at: %s.", cliPath));
+    }
+    try {
+      FileStore extractStore = Files.getFileStore(Path.of(extractDirectory));
+      FileStore archiveStore = Files.getFileStore(Path.of(archiveDirectory));
+      if (!extractStore.equals(archiveStore)) {
+        throw new ConfigurationException(
+            String.format(
+                "The extract directory '%s' and the archive directory '%s' must be located on the"
+                    + " same filesystem.",
+                extractDirectory, archiveDirectory));
+      }
+    } catch (IOException e) {
+      throw new ConfigurationException(
+          String.format(
+              "The extract directory '%s' and the archive directory '%s' must both exist.",
+              extractDirectory, archiveDirectory),
+          e);
     }
 
     this.cliPath = cliPath;
@@ -126,7 +152,7 @@ public class ScicatCli {
                           "CLI reported success, but no valid PID matching pattern was found in"
                               + " output."));
 
-      symlinkData(pid, dto.getSourceFolder(), fileList);
+      moveData(pid, dto.getSourceFolder(), fileList);
 
       scicatService.updateDataset(
           scicatToken,
@@ -158,23 +184,30 @@ public class ScicatCli {
     return ingestDataset(scicatToken, dto, Collections.emptyList());
   }
 
-  private void symlinkData(String pid, String sourceFolder, Collection<String> fileList)
+  private void moveData(String pid, String sourceFolder, Collection<String> fileList)
       throws IOException {
     Path archiveRoot = Path.of(archiveDirectory, pid);
-    log.warn("archiveRoot: {}", archiveRoot.toString());
     if (fileList.isEmpty()) {
       Files.createDirectories(archiveRoot.getParent());
-      Files.createSymbolicLink(archiveRoot, Path.of(sourceFolder));
+      move(Path.of(sourceFolder), archiveRoot);
     } else {
-      Files.createDirectories(archiveRoot);
+      Set<Path> createdDirectories = new HashSet<>();
+      createdDirectories.add(Files.createDirectories(archiveRoot));
       for (String file : fileList) {
         Path relativePath = Path.of(sourceFolder).relativize(Path.of(file));
-        Path linkPath = archiveRoot.resolve(relativePath);
-        log.warn("linkPath: {}", linkPath.toString());
-        Files.createDirectories(linkPath.getParent());
-        Files.createSymbolicLink(linkPath, Path.of(file));
+        Path targetPath = archiveRoot.resolve(relativePath);
+        Path parent = targetPath.getParent();
+        if (createdDirectories.add(parent)) {
+          Files.createDirectories(parent);
+        }
+        move(Path.of(file), targetPath);
       }
     }
+  }
+
+  private void move(Path source, Path target) throws IOException {
+    log.debug("Moving {} to {}", source, target);
+    Files.move(source, target, StandardCopyOption.ATOMIC_MOVE);
   }
 
   private void cleanupFile(Path path) {

--- a/src/test/java/ch/psi/scicat/cli/ScicatCliTest.java
+++ b/src/test/java/ch/psi/scicat/cli/ScicatCliTest.java
@@ -1,19 +1,166 @@
 package ch.psi.scicat.cli;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
+import ch.psi.scicat.client.ScicatService;
+import ch.psi.scicat.model.v3.CreateDatasetDto;
+import io.quarkus.runtime.configuration.ConfigurationException;
+import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
 import io.quarkus.test.junit.mockito.InjectSpy;
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.FieldSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 @QuarkusTest
+@TestProfile(ScicatCliTest.Profile.class)
 public class ScicatCliTest {
+  private static final Path tempDirectory = Path.of(System.getProperty("java.io.tmpdir"));
+  private static final Path cliPath = tempDirectory.resolve("scicat-cli-stub");
+  private static final Path archiveDirectory = tempDirectory.resolve("scicat-cli-archive");
+  private static final String pid = "PID.SAMPLE.PREFIX/psi-ds1";
+  private static final Path archiveRoot = archiveDirectory.resolve(pid);
+
+  public static class Profile implements QuarkusTestProfile {
+    @Override
+    public Map<String, String> getConfigOverrides() {
+      return Map.of(
+          "scicat.cli.path", cliPath.toString(),
+          "rocrate.archive-directory", archiveDirectory.toString(),
+          "rocrate.extract-directory", tempDirectory.toString());
+    }
+  }
+
   @InjectSpy ScicatCli scicatCli;
+  @InjectMock @RestClient ScicatService scicatService;
+  @TempDir Path sourceFolder;
+
+  static {
+    try {
+      Files.createDirectories(archiveDirectory);
+      Files.writeString(cliPath, String.format("#!/bin/sh%necho %s%n", pid));
+      Files.setPosixFilePermissions(cliPath, PosixFilePermissions.fromString("rwxr-xr-x"));
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  @BeforeEach
+  public void resetArchiveDirectory() throws IOException {
+    deleteRecursively(archiveDirectory);
+  }
 
   @ParameterizedTest(name = "should throw if scicat.cli.path={0} is not a file or not executable")
   @ValueSource(strings = {"non-existing", "/usr", "/etc/localtime"})
   public void test00(String cliPath) {
-    assertThrows(IllegalStateException.class, () -> new ScicatCli(cliPath, null, null, null));
+    assertThrows(
+        ConfigurationException.class, () -> new ScicatCli(cliPath, null, null, null, null));
+  }
+
+  @Test
+  @DisplayName("should throw if the extract and archive directories are on different filesystems")
+  public void test01() throws IOException {
+    Path tmpfs = Path.of("/dev/shm");
+    assumeTrue(Files.isDirectory(tmpfs), "/dev/shm is not usable");
+    assumeFalse(
+        Files.getFileStore(tmpfs).equals(Files.getFileStore(tempDirectory)),
+        "/dev/shm is on the same filesystem as the extract directory");
+
+    ConfigurationException e =
+        assertThrows(
+            ConfigurationException.class,
+            () ->
+                new ScicatCli(
+                    cliPath.toString(), null, null, tmpfs.toString(), tempDirectory.toString()));
+
+    assertTrue(e.getMessage().endsWith("must be located on the same filesystem."));
+  }
+
+  static final List<Arguments> moveMatrix =
+      List.of(
+          arguments(
+              "flat file list",
+              Set.of("first.txt", "second.txt"),
+              Set.of("first.txt", "second.txt")),
+          arguments(
+              "nested directories",
+              Set.of("data/first.txt", "data/nested/second.txt"),
+              Set.of("data/first.txt", "data/nested/second.txt")),
+          arguments(
+              "partial file list", Set.of("listed.txt", "unlisted.txt"), Set.of("listed.txt")));
+
+  @ParameterizedTest(name = "{0}")
+  @FieldSource("moveMatrix")
+  public void test02(String name, Set<String> sourceFiles, Set<String> ingested)
+      throws IOException {
+    for (String file : sourceFiles) {
+      Files.createDirectories(sourceFolder.resolve(file).getParent());
+      Files.writeString(sourceFolder.resolve(file), file);
+    }
+
+    scicatCli.ingestDataset(
+        "token",
+        new CreateDatasetDto().setSourceFolder(sourceFolder.toString()),
+        ingested.stream().map(file -> sourceFolder.resolve(file).toString()).toList());
+
+    Set<String> notIngested =
+        sourceFiles.stream().filter(file -> !ingested.contains(file)).collect(Collectors.toSet());
+    assertEquals(ingested, filesUnder(archiveRoot));
+    assertEquals(notIngested, filesUnder(sourceFolder));
+  }
+
+  @Test
+  @DisplayName("An empty file list moves the whole source folder")
+  public void test03() throws IOException {
+    Files.writeString(sourceFolder.resolve("first.txt"), "first.txt");
+
+    scicatCli.ingestDataset(
+        "token", new CreateDatasetDto().setSourceFolder(sourceFolder.toString()));
+
+    assertFalse(Files.exists(sourceFolder));
+    assertEquals(Set.of("first.txt"), filesUnder(archiveRoot));
+  }
+
+  private static Set<String> filesUnder(Path root) throws IOException {
+    try (var paths = Files.walk(root)) {
+      return paths
+          .filter(Files::isRegularFile)
+          .map(path -> root.relativize(path).toString())
+          .collect(Collectors.toSet());
+    }
+  }
+
+  private static void deleteRecursively(Path path) throws IOException {
+    if (!Files.exists(path)) {
+      return;
+    }
+    try (var paths = Files.walk(path)) {
+      paths.sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
+    }
   }
 }


### PR DESCRIPTION
Needed cause the archival system no longer follows links outside the `sourceFolder`.
If the archive and extract directories are not on the same filesystem, the application fails at startup to prevent the move operation to copy files.